### PR TITLE
bld/makdep.c: add a return type to main()

### DIFF
--- a/bld/makdep.c
+++ b/bld/makdep.c
@@ -51,7 +51,7 @@ static struct node *suffix_list;      /* List of Fortran suffixes to look for */
 static void check (char *, struct node *, char *, int);
 static int already_found (char *, struct node *);
 
-main (int argc, char **argv)
+int main (int argc, char **argv)
 {
   int lastdot;             /* points to the last . in fname */
   int c;                   /* return from getopt */


### PR DESCRIPTION
Fixes build failure with oneapi@2025.0.4
```
cc -o makdep /tmp/root/spack-stage/spack-stage-cice5-git.2023.10.19_access-om2-q26rhh7gzs7pxowlbybq555kzxij6qf2/spack-src/bld/makdep.c
/tmp/root/spack-stage/spack-stage-cice5-git.2023.10.19_access-om2-q26rhh7gzs7pxowlbybq555kzxij6qf2/spack-src/bld/makdep.c:54:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   54 | main (int argc, char **argv)
      | ^
      | int
1 error generated.
exit 2