### PR TITLE
Set netcdf output calendar attributes correctly

### DIFF
--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -203,7 +203,7 @@
            if (status /= nf90_noerr) call abort_ice( &
                          'ice Error: time calendar')
         elseif (use_leap_years) then
-           status = nf90_put_att(ncid,varid,'calendar','Gregorian')
+           status = nf90_put_att(ncid,varid,'calendar','proleptic_gregorian')
            if (status /= nf90_noerr) call abort_ice( &
                          'ice Error: time calendar')
         else


### PR DESCRIPTION
CICE [actually uses](https://github.com/ACCESS-NRI/cice5/blob/ac3d3a104e05596d4870d5a9c7e4020b407d5bb8/source/ice_calendar.F90#L536-L540) a proleptic gregorian calendar, see https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#calendar

_a leap year if either (i) it is divisible by 4 but not by 100 or (ii) it is divisible by 400._

As noted in https://github.com/ACCESS-NRI/access-esm1.6-configs/issues/90