### PR TITLE
expose ice_ref_salinity to the namelist

### DIFF
--- a/drivers/access/ice_constants.F90
+++ b/drivers/access/ice_constants.F90
@@ -44,10 +44,7 @@
 
 !ars599: 26032014 new code (CODE: dragio)
 !	use new code, mark out #ifndef AusCOM
-#ifndef AusCOM
-         !!! dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
-         dragio    = 0.01_dbl_kind ,&!!! 20170922 test new value as per spo 
-#endif
+
          albocn    = 0.06_dbl_kind      ! ocean albedo
 
       real (kind=dbl_kind), parameter, public :: &
@@ -58,10 +55,7 @@
       real (kind=dbl_kind), parameter, public :: &
          secday    = 86400.0_dbl_kind ,&! seconds in calendar day
          viscosity_dyn = 1.79e-3_dbl_kind, & ! dynamic viscosity of brine (kg/m/s)
-#ifndef AusCOM
-         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),
-                                        ! used as Tsfcn for open water
-#endif
+
          rhofresh  = 1000.0_dbl_kind  ,&! density of fresh water (kg/m^3)
          zvir      = 0.606_dbl_kind   ,&! rh2o/rair - 1.0
          vonkar    = 0.4_dbl_kind     ,&! von Karman constant
@@ -99,20 +93,24 @@
 #ifndef AusCOM
          ! multilayers with the UM coupling
          aicenmin_ml = 0.00001_dbl_kind, &! AEW: min aice we want to allow when using
-         snowpatch = 0.02_dbl_kind ! parameter for fractional snow area (m)
+         snowpatch = 0.02_dbl_kind, & ! parameter for fractional snow area (m)
 #else
          aicenmin_ml = 0.00001_dbl_kind! AEW: min aice we want to allow when using
-#endif                    
-#ifdef AusCOM
-      ! in namelist therefore not parameter, which is counterintuitive,
-      ! since this modules name is ice_constants
-!ars599: 26032014: change to public
-!ars599: 24042015: remove dragio!!
+#endif
+#ifndef AusCOM
+         !!! dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
+         dragio    = 0.01_dbl_kind ,&!!! 20170922 test new value as per spo 
+         Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),
+                                        ! used as Tsfcn for open water
+         ice_ref_salinity = 5._dbl_kind ! reference salinity for ice–ocean exchanges (ppt)
+                                        ! n.b. CICE6 uses 4 ppt
+#else
+      ! get these in ice_init from namelist
       real (kind=dbl_kind), public :: &
-         dragio   , & ! ice-ocn drag coefficient
-         Tocnfrz , &! freezing temp of seawater (C),
-                 ! used as Tsfcn for open water
-         ice_ref_salinity ! (ppt)
+         dragio   ,  & ! ice-ocn drag coefficient
+         Tocnfrz ,   & ! freezing temp of seawater (C),
+                       ! used as Tsfcn for open water
+         ice_ref_salinity ! reference salinity for ice–ocean exchanges (ppt)
 #endif
 
       ! weights for albedos 

--- a/drivers/access/ice_constants.F90
+++ b/drivers/access/ice_constants.F90
@@ -91,13 +91,12 @@
          !!!ksno   = 0.50_dbl_kind  ,&!!! test new value as per spo
          zref   = 10._dbl_kind   ,&! reference height for stability (m)
 #ifndef AusCOM
-         ! multilayers with the UM coupling
-         aicenmin_ml = 0.00001_dbl_kind, &! AEW: min aice we want to allow when using
          snowpatch = 0.02_dbl_kind, & ! parameter for fractional snow area (m)
-#else
-         aicenmin_ml = 0.00001_dbl_kind! AEW: min aice we want to allow when using
 #endif
+         ! multilayers with the UM coupling
+         aicenmin_ml = 0.00001_dbl_kind! AEW: min aice we want to allow when using
 #ifndef AusCOM
+      real (kind=dbl_kind), parameter, public :: &
          !!! dragio    = 0.00536_dbl_kind ,&! ice-ocn drag coefficient
          dragio    = 0.01_dbl_kind ,&!!! 20170922 test new value as per spo 
          Tocnfrz   = -1.8_dbl_kind    ,&! freezing temp of seawater (C),

--- a/drivers/access/ice_constants.F90
+++ b/drivers/access/ice_constants.F90
@@ -73,7 +73,6 @@
          Lfresh    = Lsub-Lvap        ,&! latent heat of melting of fresh ice (J/kg)
          Timelt    = 0.0_dbl_kind     ,&! melting temperature, ice top surface  (C)
          Tsmelt    = 0.0_dbl_kind     ,&! melting temperature, snow top surface (C)
-         ice_ref_salinity = 5._dbl_kind, &!8._dbl_kind ,&! (ppt)
 !        ocn_ref_salinity = 34.7_dbl_kind,&! (ppt)
          spval_dbl = 1.0e30_dbl_kind    ! special value (double precision)
 
@@ -111,8 +110,9 @@
 !ars599: 24042015: remove dragio!!
       real (kind=dbl_kind), public :: &
          dragio   , & ! ice-ocn drag coefficient
-         Tocnfrz ! freezing temp of seawater (C),
+         Tocnfrz , &! freezing temp of seawater (C),
                  ! used as Tsfcn for open water
+         ice_ref_salinity ! (ppt)
 #endif
 
       ! weights for albedos 

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -42,7 +42,7 @@
       use ice_broadcast, only: broadcast_scalar, broadcast_array
 !ars599: 24042015 for the namelist variables
       use ice_constants, only: c0, c1, puny, dragio, &
-          awtvdr, awtidr, awtvdf, awtidf, Tocnfrz
+          awtvdr, awtidr, awtvdf, awtidf, Tocnfrz, ice_ref_salinity
       use ice_diagnostics, only: diag_file, print_global, print_points, latpnt, lonpnt
       use ice_domain_size, only: max_nstrm, nilyr, nslyr, max_ntrcr, ncat, n_aero
       use ice_fileunits, only: nu_nml, nu_diag, nml_filename, diag_type, &
@@ -144,7 +144,7 @@
         a_rapid_mode,   Rac_rapid_mode,  aspect_rapid_mode,             &
 !ars599: 24092014 (CODE: petteri)
 #ifdef AusCOM
-	chio,                                                           &
+	chio, ice_ref_salinity,                                              &
 #endif
         saltmax, dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy
 
@@ -315,6 +315,7 @@
       Tocnfrz  = -1.8_dbl_kind   ! freezing temp of seawater (C),
                                  ! used as Tsfcn for open water
       chio     = 0.006_dbl_kind  ! unitless param for basal heat flx ala McPhee and Maykut
+      ice_ref_salinity = 5._dbl_kind
 #endif
       atmbndy   = 'default'       ! or 'constant'
 
@@ -790,6 +791,7 @@
       call broadcast_scalar(sinw,               master_task)
       call broadcast_scalar(dragio,             master_task)
       call broadcast_scalar(chio,               master_task)
+      call broadcast_scalar(ice_ref_salinity,   master_task)
       call broadcast_scalar(Tocnfrz,            master_task)
 #endif
       call broadcast_scalar(atmbndy,            master_task)
@@ -1030,6 +1032,8 @@
          write(nu_diag,1005) ' sinw                      = ', sinw
          write(nu_diag,1005) ' dragio                    = ', dragio
          write(nu_diag,1005) ' chio                      = ', chio
+         write(nu_diag,1005) ' ice_ref_salinity          = ', ice_ref_salinity
+
 #endif
          write(nu_diag,1005) ' ustar_min                 = ', ustar_min
          write(nu_diag, *)   ' fbot_xfer_type            = ', &


### PR DESCRIPTION
This makes the assumed salinity of sea ice configurable, so we can set it the same as the MOM value

(configured in MOM [here](https://github.com/ACCESS-NRI/access-esm1.6-configs/blob/88ac5aab5d6d2500209b7d610e68e5c2928222d4/ocean/input.nml#L367))

We use 4ppt in MOM for historical reasons, and did that in [CICE4](https://github.com/ACCESS-NRI/cice4/blob/694a9fbd4ac29dc841b38aff002eb36da5b650f1/source/ice_init.F90#L243) too.