### PR TITLE
Implement dump last in ESM1.6 driver

### DIFF
--- a/drivers/access/CICE_RunMod.F90
+++ b/drivers/access/CICE_RunMod.F90
@@ -48,7 +48,8 @@
       use ice_calendar, only: istep, istep1, time, dt, stop_now, calendar
       use ice_forcing, only: get_forcing_atmo, get_forcing_ocn
 #ifdef ACCESS
-      use ice_calendar, only: month, mday, istep, istep1, time, dt, stop_now, calendar
+      use ice_calendar, only: month, mday, istep, istep1, time, dt, stop_now, calendar, &
+          write_restart, dump_last
       use ice_restart_driver, only: dumpfile     !temporary debug
 #endif
       use ice_flux, only: init_flux_atm, init_flux_ocn
@@ -135,6 +136,11 @@
           !      ' calling dumpfile at icpl_ai, itap, time_sec, idate = ', icpl_ai, itap, time_sec, idate
           !  call dumpfile
           !endif
+
+          ! Write restart on final timestep
+          if (dump_last .and. (itap == num_ice_ai) .and. (icpl_ai == num_cpl_ai)) then
+            write_restart = 1
+          endif
  
           !*** ice "update" ***!
           call ice_step

--- a/source/ice_calendar.F90
+++ b/source/ice_calendar.F90
@@ -296,7 +296,6 @@
       write(il_out,*) '(calendar)  idate = ', idate
 #endif
       if (istep >= npt+1)  stop_now = 1
-      if (istep == npt .and. dump_last) write_restart = 1 ! last timestep
       if (nyr   /= nyrp)   new_year = .true.
       if (month /= monthp) new_month = .true.
       if (mday  /= mdayp)  new_day = .true.

--- a/source/ice_calendar.F90
+++ b/source/ice_calendar.F90
@@ -296,6 +296,9 @@
       write(il_out,*) '(calendar)  idate = ', idate
 #endif
       if (istep >= npt+1)  stop_now = 1
+#ifndef ACCESS
+      if (istep == npt .and. dump_last) write_restart = 1 ! last timestep
+#endif
       if (nyr   /= nyrp)   new_year = .true.
       if (month /= monthp) new_month = .true.
       if (mday  /= mdayp)  new_day = .true.


### PR DESCRIPTION
Closes #37 

This PR modifies the `dump_last` implementation for the ESM1.6 driver. Rather than checking against `npt` (not used in ESM1.6), it sets `write_restart = 1` in the last timestep of the control loop.

### Testing
To check whether it's writing restarts at the correct times with the correct data, I ran 3 simulations with `dump_last=.true.`:
- A 1 month simulation with `dumpfreq='y'`
- A 3 month simulation with `dumpfreq='y'`
- A 5 day simulation with `dumpfreq='m'`
In each case, `dump_last` would be responsible for writing the restart at the end of the run.

And 3 runs with `dump_last=.false.` for comparison:
- A 1 month simulation with `dumpfreq='m'`
- A 3 month simulation with `dumpfreq='m'`
- A 5 day simulation with `dumpfreq='d'`
The standard date-based checks would be responsible for writing the final restarts for these runs.


In each case, the end of run restart files match:

```
> nccmp -dg dump_last_1M/archive/restart000/ice/iced.0786-02-01-00000.nc standard_1M/archive/restart000/ice/iced.0786-02-01-00000.nc 

> nccmp -dg dump_last_1M/archive/restart000/ice/mice.nc standard_1M/archive/restart000/ice/mice.nc

> nccmp -dg dump_last_3M/archive/restart000/ice/iced.0786-04-01-00000.nc standard_3M/archive/restart000/ice/iced.0786-04-01-00000.nc 

> nccmp -dg dump_last_3M/archive/restart000/ice/mice.nc standard_3M/archive/restart000/ice/mice.nc

> nccmp -dg dump_last_5D/archive/restart000/ice/iced.0786-01-06-00000.nc standard_5D/archive/restart000/ice/iced.0786-01-06-00000.nc 

> nccmp -dg dump_last_5D/archive/restart000/ice/mice.nc standard_5D/archive/restart000/ice/mice.nc
```

The coupler restart files also match for each pair of runs.