### PR TITLE
Set cp_ocn to same value as MOM

### DIFF
--- a/drivers/access/ice_constants.F90
+++ b/drivers/access/ice_constants.F90
@@ -33,7 +33,6 @@
          cp_ice    = 2106._dbl_kind   ,&! specific heat of fresh ice (J/kg/K)
 !ars599: 11042014: add AusCOM
 #ifdef AusCOM
-
          cp_ocn    = 3989.24495292815_dbl_kind, & ! mom5 constant
          ! cp_ocn    = 3992.10322329649_dbl_kind,& ! used for cm2
 #else


### PR DESCRIPTION
Set the specific heat of ocn consistently across components.

It's hard to set this in the namelist because it is used at compile tile to define several parameters

Set per MOM5 value:

https://github.com/ACCESS-NRI/FMS/blob/bf9b80423ea4f66efa389e03d3c19b26c009e8b6/constants/constants.F90#L90