### PR TITLE
ESM1.6: Write current year to restart

### DIFF
--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -174,6 +174,10 @@
          status = nf90_put_att(ncid,nf90_global,'month',month)
          status = nf90_put_att(ncid,nf90_global,'mday',mday)
          status = nf90_put_att(ncid,nf90_global,'sec',sec)
+#ifdef ACCESS
+        iyear = nyr + year_init - 1 ! Current model year for use in next run
+        status = nf90_put_att(ncid,nf90_global,'year',iyear)
+#endif
 
          nx = nx_global
          ny = ny_global


### PR DESCRIPTION
Closes #45. Adds a `year` attribute to the restart files so that the next run's calendar can be correctly initialised.

To start with, the `year` attribute will be read and handled by payu. In the future (see #25), `year` will be read directly by the model.

Details of testing to be added
