### PR TITLE
fail on non midnight restarts

### DIFF
--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -78,6 +78,15 @@
             status = nf90_get_att(ncid, nf90_global, 'mday', mday)
             status = nf90_get_att(ncid, nf90_global, 'sec', sec)
          endif
+
+         if ( sec .ne. 0 ) then
+            call abort_ice(
+               'ice: restart ncfile '//trim(filename)//&
+               ' has restart "sec" attribute not set to 0'//&
+               ' This is not supported as a start time.'
+            )
+         endif
+
          endif ! use namelist values if use_restart_time = F
 
          write(nu_diag,*) 'Restart read at istep=',istep0,time,time_forc


### PR DESCRIPTION
By this comment, fail if trying to start at times other than midnight

https://github.com/payu-org/payu/pull/585/files#r2156269055

All other methods of starting from a configured runtime have sec hardcoded to 0 (e.g. https://github.com/ACCESS-NRI/cice5/blob/89ff69aadfe9ae9f80b90d287a6e810e0f27e6d8/source/ice_calendar.F90#L139-L140)

Contributes to #25 