### PR TITLE
Use ifort for preprocessor directives

### DIFF
--- a/bld/Makefile
+++ b/bld/Makefile
@@ -113,11 +113,11 @@ $(EXEC): $(OBJS)
 	cc $(CFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $<
 
 .F.o:
-	$(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< > $*.f 
+	$(FC) -P $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< -o $*.f
 	$(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(INCS) $(INCLDIR) $*.f  
 
 .F90.o:
-	$(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< > $*.f90
+	$(FC) -P $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< -o $*.f90
 	$(FC) -c $(FFLAGS) $(FREEFLAGS) $(INCS) $(INCLDIR) $*.f90  
 
 mostlyclean:

--- a/bld/Makefile.std
+++ b/bld/Makefile.std
@@ -113,11 +113,11 @@ $(EXEC): $(OBJS)
 	cc $(CFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $<
 
 .F.o:
-	$(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< > $*.f 
+	$(FC) -P $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< -o $*.f
 	$(FC) -c $(FFLAGS) $(FIXEDFLAGS) $(INCS) $(INCLDIR) $*.f  
 
 .F90.o:
-	$(CPP) $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< > $*.f90
+	$(FC) -P $(CPPFLAGS) $(CPPDEFS) $(INCS) $(INCLDIR) $< -o $*.f90
 	$(FC) -c $(FFLAGS) $(FREEFLAGS) $(INCS) $(INCLDIR) $*.f90  
 
 mostlyclean:


### PR DESCRIPTION
So that `__INTEL_COMPILER_` is defined, use ifort for preprocessing CPP directives.

Closes #51 