### PR TITLE
Set aicenmin consistent with UM7.3

### DIFF
--- a/source/ice_itd.F90
+++ b/source/ice_itd.F90
@@ -242,7 +242,8 @@
         hi_min   = p2     ! 0.2m
         hs_min   = p1     ! 0.1m
       else
-        aicenmin = puny   ! Standard CICE setting
+        !  aicenmin = puny   ! Standard CICE setting
+        aicenmin = 2.0e-4_dbl_kind   ! Same as setting in UM7.3 for ESM1.6
       endif
 
       if (my_task == master_task) then


### PR DESCRIPTION
When using zero layer ice, set aicenmin consistently with UM7.3

https://github.com/ACCESS-NRI/UM7/blob/e6d003b90577e99584dcda04aed010dd722af360/umbase_hg3/src/control/coupling/oasis3_geto2a.F90#L532-L534

contributes to #19