### PR TITLE
Mask iceberg data file upon reading

### DIFF
--- a/drivers/access/cpl_forcing_handler.F90
+++ b/drivers/access/cpl_forcing_handler.F90
@@ -427,7 +427,16 @@ else
   write(il_out,'(a,a)') '(get_lice_discharge) reading in iceberg data, myvar= ',trim(myvar)
   do im = 1, 12
     write(il_out,*) '(get_lice_discharge) reading in data, month= ',im
-    call ice_read_global_nc(ncid_i2o, im, trim(myvar), gwork, dbug)
+    call ice_read_nc(ncid_i2o, im, trim(myvar), vwork, dbug)
+
+    ! Restrict iceberg fluxes to ocean points
+    where (tmask)
+      vwork = vwork
+    else where
+      vwork = c0
+    end where
+
+    call gather_global(gwork, vwork, master_task, distrb_info)
 
     if ( my_task == master_task ) then 
       gicebergfw(:,:,im) = gwork(:,:)


### PR DESCRIPTION
See #39 for details.

The iceberg scheme redistributes runoff received from the UM into runoff along the ice sheet coastlines and an iceberg flux. The iceberg flux is spread out over the ocean around the ice sheets, with spatial distribution defined by the `lice_discharge_iceberg.nc` file. 

However, som non-zero points in our iceberg file (`/g/data/vk83/prerelease/configurations/inputs/access-esm1p6/modern/share/ice/iceberg/global.1deg/2024.11.08/lice_discharge_iceberg.nc`) fall on land points in the cice/ocean mask.

This means that when the UM runoff is redistributed, a small amount of the iceberg flux is sent to land and is then lost.

This PR applies the land mask to the iceberg pattern when it is read in. This should make sure that the iceberg flux is only sent to ocean points.

To test this, I tried adding some custom CICE diagnostics for the runoff received from the UM, the runoff sent to MOM, and the iceberg flux sent to MOM. I saved copies both with and without the land mask being applied to the history output. I did one run with the changes in this PR, and one without.

The following shows CICE's iceberg flux on land points with and without the changes:

![download-20](https://github.com/user-attachments/assets/557b2491-f970-438c-b703-e0d4edbd53d1)

The following shows the total iceberg flux onto land:

![download-22](https://github.com/user-attachments/assets/9897bea5-9711-4a0b-b1c7-7a6e5ba500c4)



The following shows the difference between the `um_runoff` (masked) received by CICE, and the `runoff+licefw` received by MOM. The difference should be 0 if all runoff received by CICE is sent to MOM:

![download-26](https://github.com/user-attachments/assets/4a2af043-321d-41d0-89b4-dbe46a79ff64)


The following shows the total water mass added up over all the components, UM+MOM+CICE. Both runs use `add_lprec=0`:
![download-27](https://github.com/user-attachments/assets/1a381f1f-3161-4712-9617-13a7fb15f70d)

Both these runs started from the same restart, but I only added the right diagnostics 25 years in. 


