### PR TITLE
Merge netcdf code from master branch

### DIFF
--- a/drivers/access/cpl_parameters.F90
+++ b/drivers/access/cpl_parameters.F90
@@ -252,7 +252,7 @@ if (nml_error /= 0) then
    endif
 endif
 
-!hardrwire dt_cpl_io == dt_cice
+!hardwire dt_cpl_io == dt_cice
 dt_cpl_io = dt_cice
 
 ! * make sure runtime is mutliple of dt_cpl_ai, dt_cpl_ai is mutliple of dt_cpl_io, 

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -957,6 +957,9 @@ end subroutine check
         call check(nf90_put_att(ncid,nf90_global,'source',title), &
                    'global attribute source')
 
+#if defined(AUSCOM) && !defined(ACCESS)
+        write(title,'(a,i3,a)') 'This Year Has ',int(dayyr),' days'
+#else
         if (use_leap_years) then
           write(title,'(a,i3,a)') 'This year has ',int(dayyr),' days'
         else

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -1006,6 +1006,11 @@ end subroutine check
 
         call check(nf90_inq_varid(ncid,'time',varid), &
                    'inq varid time')
+        if (history_parallel_io) then
+          ! unlimited dimensions need to have collective access set
+          call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+                   'parallel access time')
+        endif
         call check(nf90_put_var(ncid,varid,ltime), &
                    'put var time')
 

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -19,14 +19,65 @@
 
       module ice_history_write
 
+    use netcdf
+    use mpi, only: MPI_INFO_NULL, MPI_COMM_WORLD
+
+    use ice_kinds_mod
+    use ice_constants, only: c0, c360, secday, spval, rad_to_deg
+    use ice_blocks, only: nx_block, ny_block, block, get_block
+    use ice_exit, only: abort_ice
+    use ice_domain, only: distrb_info, nblocks, blocks_ice
+    use ice_domain, only: equal_num_blocks_per_cpu
+    use ice_communicate, only: my_task, master_task, MPI_COMM_ICE
+    use ice_broadcast, only: broadcast_scalar
+    use ice_gather_scatter, only: gather_global
+    use ice_domain_size, only: nx_global, ny_global, max_nstrm, max_blocks
+    use ice_grid, only: TLON, TLAT, ULON, ULAT, hm, bm, tarea, uarea, &
+        dxu, dxt, dyu, dyt, HTN, HTE, ANGLE, ANGLET, &
+        lont_bounds, latt_bounds, lonu_bounds, latu_bounds
+    use ice_history_shared
+    use ice_itd, only: hin_max
+    use ice_calendar, only: write_ic, histfreq
+
+
       implicit none
       private
       public :: ice_write_hist
       save
-      
-!=======================================================================
+
+    type coord_attributes         ! netcdf coordinate attributes
+      character (len=11)   :: short_name
+      character (len=45)   :: long_name
+      character (len=20)   :: units
+    end type coord_attributes
+
+    type req_attributes         ! req'd netcdf attributes
+      type (coord_attributes) :: req
+      character (len=20)   :: coordinates
+    end type req_attributes
+
+    ! 4 coordinate variables: TLON, TLAT, ULON, ULAT
+    INTEGER (kind=int_kind), PARAMETER :: ncoord = 4
+
+    ! 4 vertices in each grid cell
+    INTEGER (kind=int_kind), PARAMETER :: nverts = 4
+
+    ! 4 variables describe T, U grid boundaries:
+    ! lont_bounds, latt_bounds, lonu_bounds, latu_bounds
+    INTEGER (kind=int_kind), PARAMETER :: nvar_verts = 4
 
       contains
+
+
+subroutine check(status, msg)
+    integer, intent (in) :: status
+    character(len=*), intent (in) :: msg
+
+    if(status /= nf90_noerr) then
+        call abort_ice('ice: NetCDF error '//trim(nf90_strerror(status)//' '//trim(msg)))
+    end if
+end subroutine check
+
 
 !=======================================================================
 !
@@ -36,33 +87,18 @@
 
       subroutine ice_write_hist (ns)
 
-      use ice_kinds_mod
-#ifdef ncdf
-      use ice_blocks, only: nx_block, ny_block
-      use ice_broadcast, only: broadcast_scalar
-      use ice_calendar, only: time, sec, idate, idate0, write_ic, &
-          histfreq, dayyr, days_per_year, use_leap_years, month, daymo
-      use ice_communicate, only: my_task, master_task
-      use ice_constants, only: c0, c360, secday, spval, rad_to_deg
-      use ice_domain, only: distrb_info
-      use ice_domain_size, only: nx_global, ny_global, max_nstrm, max_blocks
-      use ice_exit, only: abort_ice
-      use ice_fileunits, only: nu_diag
-      use ice_gather_scatter, only: gather_global
-      use ice_grid, only: TLON, TLAT, ULON, ULAT, hm, bm, tarea, uarea, &
-          dxu, dxt, dyu, dyt, HTN, HTE, ANGLE, ANGLET, &
-          lont_bounds, latt_bounds, lonu_bounds, latu_bounds
-      use ice_history_shared
-      use ice_itd, only: hin_max
-      use ice_restart_shared, only: runid
-      use netcdf
+            use ice_calendar, only: time, sec, idate, idate0, &
+#ifdef ACCESS
+        month, daymo, &
 #endif
+        dayyr, days_per_year, use_leap_years
+      use ice_fileunits, only: nu_diag
+      use ice_restart_shared, only: runid
 
       integer (kind=int_kind), intent(in) :: ns
 
       ! local variables
 
-#ifdef ncdf
       real (kind=dbl_kind),  dimension(:,:),   allocatable :: work_g1
       real (kind=real_kind), dimension(:,:),   allocatable :: work_gr
       real (kind=real_kind), dimension(:,:,:), allocatable :: work_gr3
@@ -71,7 +107,7 @@
 
       integer (kind=int_kind) :: i,k,ic,n,nn, &
          ncid,status,imtid,jmtid,kmtidi,kmtids,kmtidb, cmtid,timid,varid, &
-         nvertexid,ivertex,iflag
+         nvertexid,ivertex
       integer (kind=int_kind), dimension(3) :: dimid
       integer (kind=int_kind), dimension(4) :: dimidz
       integer (kind=int_kind), dimension(5) :: dimidcz
@@ -81,31 +117,12 @@
       character (char_len) :: title
       character (char_len_long) :: ncfile(max_nstrm)
 
+      integer (kind=int_kind) :: shuffle, deflate, deflate_level
+
       integer (kind=int_kind) :: ind,boundid
 
       character (char_len) :: start_time,current_date,current_time
       character (len=8) :: cdate
-
-      ! 4 coordinate variables: TLON, TLAT, ULON, ULAT
-      INTEGER (kind=int_kind), PARAMETER :: ncoord = 4
-
-      ! 4 vertices in each grid cell
-      INTEGER (kind=int_kind), PARAMETER :: nverts = 4
-
-      ! 4 variables describe T, U grid boundaries:
-      ! lont_bounds, latt_bounds, lonu_bounds, latu_bounds
-      INTEGER (kind=int_kind), PARAMETER :: nvar_verts = 4
-
-      TYPE coord_attributes         ! netcdf coordinate attributes
-        character (len=11)   :: short_name
-        character (len=45)   :: long_name
-        character (len=20)   :: units
-      END TYPE coord_attributes
-
-      TYPE req_attributes         ! req'd netcdf attributes
-        type (coord_attributes) :: req
-        character (len=20)   :: coordinates
-      END TYPE req_attributes
 
       TYPE(req_attributes), dimension(nvar) :: var
       TYPE(coord_attributes), dimension(ncoord) :: coord_var
@@ -113,8 +130,21 @@
       TYPE(coord_attributes), dimension(nvarz) :: var_nz
       CHARACTER (char_len), dimension(ncoord) :: coord_bounds
 
-      if (my_task == master_task) then
-#if defined(AusCOM) || defined(ACCESS)
+      ! We leave shuffle at 0, this is only useful for integer data.
+      shuffle = 0
+
+      ! If history_deflate_level < 0 then don't do deflation,
+      ! otherwise it sets the deflate level
+      if (history_deflate_level < 0) then
+         deflate = 0
+         deflate_level = 0
+      else
+         deflate = 1
+         deflate_level = history_deflate_level
+      endif
+
+      if (my_task == master_task .or. history_parallel_io) then
+#if defined(ACCESS)
         ! set timestamp in middle of time interval
         if (histfreq(ns) == 'm' .or. histfreq(ns) == 'M') then
             if (month /= 1) then
@@ -141,92 +171,74 @@
         endif
 
         ! create file
-        iflag = ior(NF90_NETCDF4, NF90_CLOBBER)
-        status = nf90_create(ncfile(ns), iflag, ncid)
-        if (status /= nf90_noerr) call abort_ice( &
-           'ice: Error creating history ncfile '//ncfile(ns))
+        if (history_parallel_io) then
+            call check(nf90_create(ncfile(ns), ior(NF90_NETCDF4, NF90_MPIIO), ncid, &
+                                   comm=MPI_COMM_ICE, info=MPI_INFO_NULL), &
+                        'create history ncfile '//ncfile(ns))
+            if (.not. equal_num_blocks_per_cpu) then
+                call abort_ice('ice: error history_parallel_io needs equal_num_blocks_per_cpu')
+            endif
+        else
+            call check(nf90_create(ncfile(ns), ior(NF90_CLASSIC_MODEL, NF90_HDF5), ncid), &
+                        'create history ncfile '//ncfile(ns))
+        endif
 
       !-----------------------------------------------------------------
       ! define dimensions
       !-----------------------------------------------------------------
 
         if (hist_avg) then
-          status = nf90_def_dim(ncid,'d2',2,boundid)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error defining dim d2')
+            call check(nf90_def_dim(ncid,'d2',2,boundid), 'def dim d2')
         endif
 
-        status = nf90_def_dim(ncid,'ni',nx_global,imtid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim ni')
-
-        status = nf90_def_dim(ncid,'nj',ny_global,jmtid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nj')
-
-        status = nf90_def_dim(ncid,'nc',ncat_hist,cmtid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nc')
-
-        status = nf90_def_dim(ncid,'nkice',nzilyr,kmtidi)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nki')
-
-        status = nf90_def_dim(ncid,'nksnow',nzslyr,kmtids)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nks')
-
-        status = nf90_def_dim(ncid,'nkbio',nzblyr,kmtidb)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nkb')
-
-        status = nf90_def_dim(ncid,'time',NF90_UNLIMITED,timid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim time')
-
-        status = nf90_def_dim(ncid,'nvertices',nverts,nvertexid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining dim nverts')
+        call check(nf90_def_dim(ncid, 'ni', nx_global, imtid), &
+                    'def dim ni')
+        call check(nf90_def_dim(ncid, 'nj', ny_global, jmtid), &
+                    'def dim nj')
+        call check(nf90_def_dim(ncid, 'nc', ncat_hist, cmtid), &
+                    'def dim nc')
+        call check(nf90_def_dim(ncid, 'nkice', nzilyr, kmtidi), &
+                    'def dim nkice')
+        call check(nf90_def_dim(ncid, 'nksnow', nzslyr, kmtids), &
+                    'def dim nksnow')
+        call check(nf90_def_dim(ncid, 'nkbio', nzblyr, kmtidb), &
+                    'def dim nkbio')
+        call check(nf90_def_dim(ncid, 'time', NF90_UNLIMITED, timid), &
+                    'def dim time')
+        call check(nf90_def_dim(ncid, 'nvertices', nverts, nvertexid), &
+                    'def dim nverts')
 
       !-----------------------------------------------------------------
       ! define coordinate variables
       !-----------------------------------------------------------------
 
-        status = nf90_def_var(ncid,'time',nf90_float,timid,varid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error defining var time')
-
-        status = nf90_put_att(ncid,varid,'long_name','model time')
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: time long_name')
+        call check(nf90_def_var(ncid,'time',nf90_float,timid,varid), &
+                      'def var time')
+        call check(nf90_put_att(ncid,varid,'long_name','model time'), &
+                    'put_att long_name')
 
         write(cdate,'(i8.8)') idate0
         write(title,'(a,a,a,a,a,a,a,a)') 'days since ', &
               cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
-        status = nf90_put_att(ncid,varid,'units',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: time units')
+        call check(nf90_put_att(ncid,varid,'units',title), &
+                    'put_att time units')
 
         if (days_per_year == 360) then
-           status = nf90_put_att(ncid,varid,'calendar','360_day')
-           if (status /= nf90_noerr) call abort_ice( &
-                         'ice Error: time calendar')
+            call check(nf90_put_att(ncid,varid,'calendar','360_day'), &
+                         'att time calendar')
         elseif (days_per_year == 365 .and. .not.use_leap_years ) then
-           status = nf90_put_att(ncid,varid,'calendar','NoLeap')
-           if (status /= nf90_noerr) call abort_ice( &
-                         'ice Error: time calendar')
+            call check(nf90_put_att(ncid,varid,'calendar','NoLeap'), &
+                         'att time calendar')
         elseif (use_leap_years) then
-           status = nf90_put_att(ncid,varid,'calendar','proleptic_gregorian')
-           if (status /= nf90_noerr) call abort_ice( &
-                         'ice Error: time calendar')
+            call check(nf90_put_att(ncid,varid,'calendar','proleptic_gregorian'), &
+                         'att time calendar')
         else
            call abort_ice( 'ice Error: invalid calendar settings')
         endif
 
         if (hist_avg) then
-          status = nf90_put_att(ncid,varid,'bounds','time_bounds')
-          if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: time bounds')
+            call check(nf90_put_att(ncid,varid,'bounds','time_bounds'), &
+                        'att time bounds')
         endif
 
       !-----------------------------------------------------------------
@@ -236,19 +248,18 @@
         if (hist_avg) then
           dimid(1) = boundid
           dimid(2) = timid
-          status = nf90_def_var(ncid,'time_bounds',nf90_float,dimid(1:2),varid)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error defining var time_bounds')
-          status = nf90_put_att(ncid,varid,'long_name', &
-                                'boundaries for time-averaging interval')
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice Error: time_bounds long_name')
+          call check(nf90_def_var(ncid, 'time_bounds', &
+                                nf90_float,dimid(1:2),varid), &
+                      'def var time_bounds')
+
+          call check(nf90_put_att(ncid,varid,'long_name', &
+                              'boundaries for time-averaging interval'), &
+                      'att time_bounds long_name')
           write(cdate,'(i8.8)') idate0
           write(title,'(a,a,a,a,a,a,a,a)') 'days since ', &
                 cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
-          status = nf90_put_att(ncid,varid,'units',title)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice Error: time_bounds units')
+          call check(nf90_put_att(ncid,varid,'units',title), &
+                                'att time_bounds units')
         endif
 
       !-----------------------------------------------------------------
@@ -335,110 +346,144 @@
         dimid(3) = timid
 
         do i = 1, ncoord
-          status = nf90_def_var(ncid, coord_var(i)%short_name, nf90_float, &
-                                dimid(1:2), varid)
-          if (status /= nf90_noerr) call abort_ice( &
-               'Error defining short_name for '//coord_var(i)%short_name)
-          status = nf90_put_att(ncid,varid,'long_name',coord_var(i)%long_name)
-          if (status /= nf90_noerr) call abort_ice( &
-               'Error defining long_name for '//coord_var(i)%short_name)
-          status = nf90_put_att(ncid, varid, 'units', coord_var(i)%units)
-          if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining units for '//coord_var(i)%short_name)
-          status = nf90_put_att(ncid,varid,'missing_value',spval)
-          if (status /= nf90_noerr) call abort_ice( &
-             'Error defining missing_value for '//coord_var(i)%short_name)
-          status = nf90_put_att(ncid,varid,'_FillValue',spval)
-          if (status /= nf90_noerr) call abort_ice( &
-             'Error defining _FillValue for '//coord_var(i)%short_name)
+          call check(nf90_def_var(ncid, coord_var(i)%short_name, nf90_float, &
+                                  dimid(1:2), varid), &
+                     'def var '//coord_var(i)%short_name)
+
+          if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+            call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                        (/ history_chunksize_x, history_chunksize_y /)), &
+                       'def var chunking '//coord_var(i)%short_name)
+          endif
+
+          call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                        deflate_level), &
+                     'deflate '//coord_var(i)%short_name)
+
+          call check(nf90_put_att(ncid,varid,'long_name',coord_var(i)%long_name), &
+                        'put att long_name '//coord_var(i)%short_name)
+          call check(nf90_put_att(ncid, varid, 'units', coord_var(i)%units), &
+                        'put att units '//coord_var(i)%short_name)
+          call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                     'put att missing_value '//coord_var(i)%short_name)
+
+          call check(nf90_put_att(ncid, varid, '_FillValue', spval), &
+                        'put att _FillValue '//coord_var(i)%short_name)
+
           if (coord_var(i)%short_name == 'ULAT') then
-             status = nf90_put_att(ncid,varid,'comment', &
-                  'Latitude of NE corner of T grid cell')
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining comment for '//coord_var(i)%short_name)
+             call check(nf90_put_att(ncid,varid,'comment', &
+                                     'Latitude of NE corner of T grid cell'), &
+                        'put att comment for '//coord_var(i)%short_name)
           endif
           if (f_bounds) then
-              status = nf90_put_att(ncid, varid, 'bounds', coord_bounds(i))
-              if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining bounds for '//coord_var(i)%short_name)
-          endif          
+              call check(nf90_put_att(ncid, varid, 'bounds', coord_bounds(i)), &
+                            'put att bounds '//coord_var(i)%short_name)
+          endif
+
         enddo
+
 
         ! Extra dimensions (NCAT, NZILYR, NZSLYR, NZBLYR)       
           dimidex(1)=cmtid
           dimidex(2)=kmtidi
           dimidex(3)=kmtids
           dimidex(4)=kmtidb
-        
+
         do i = 1, nvarz
            if (igrdz(i)) then
-             status = nf90_def_var(ncid, var_nz(i)%short_name, &
-                                   nf90_float, dimidex(i), varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining short_name for '//var_nz(i)%short_name)
-             status = nf90_put_att(ncid,varid,'long_name',var_nz(i)%long_name)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining long_name for '//var_nz(i)%short_name)
-             status = nf90_put_att(ncid, varid, 'units', var_nz(i)%units)
-             if (Status /= nf90_noerr) call abort_ice( &
-                'Error defining units for '//var_nz(i)%short_name)
+                call check(nf90_def_var(ncid, var_nz(i)%short_name, &
+                                      nf90_float, dimidex(i), varid), &
+                          'def var '//var_nz(i)%short_name)
+
+                call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                                deflate_level), &
+                           'deflate '//var_nz(i)%short_name)
+
+                call check(nf90_put_att(ncid,varid,'long_name',var_nz(i)%long_name), &
+                            'put att long_name '//var_nz(i)%short_name)
+                call check(nf90_put_att(ncid, varid, 'units', var_nz(i)%units), &
+                            'for att units '//var_nz(i)%short_name)
            endif
         enddo
 
         ! Attributes for tmask, blkmask defined separately, since they have no units
         if (igrd(n_tmask)) then
-           status = nf90_def_var(ncid, 'tmask', nf90_float, dimid(1:2), varid)
-           if (status /= nf90_noerr) call abort_ice( &
-                         'ice: Error defining var tmask')
-           status = nf90_put_att(ncid,varid, 'long_name', 'ocean grid mask') 
-           if (status /= nf90_noerr) call abort_ice('ice Error: tmask long_name') 
-           status = nf90_put_att(ncid, varid, 'coordinates', 'TLON TLAT')
-           if (status /= nf90_noerr) call abort_ice('ice Error: tmask units') 
-           status = nf90_put_att(ncid,varid,'comment', '0 = land, 1 = ocean')
-           if (status /= nf90_noerr) call abort_ice('ice Error: tmask comment') 
-           status = nf90_put_att(ncid,varid,'missing_value',spval)
-           if (status /= nf90_noerr) call abort_ice('Error defining missing_value for tmask')
-           status = nf90_put_att(ncid,varid,'_FillValue',spval)
-           if (status /= nf90_noerr) call abort_ice('Error defining _FillValue for tmask')
+            call check(nf90_def_var(ncid, 'tmask', nf90_float, dimid(1:2), varid), &
+                       'def var tmask')
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                            (/ history_chunksize_x, history_chunksize_y /)), &
+                           'def var chunking tmask')
+            endif
+
+            call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                        deflate_level), 'deflating var tmask')
+
+            call check(nf90_put_att(ncid,varid, 'long_name', 'ocean grid mask'), &
+                        'put att tmask long_name')
+            call check(nf90_put_att(ncid, varid, 'coordinates', 'TLON TLAT'), &
+                       'put att tmask units')
+            call check(nf90_put_att(ncid,varid,'comment', '0 = land, 1 = ocean'), &
+                       'put att tmask comment')
+            call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                       'put att missing_value for tmask')
+            call check(nf90_put_att(ncid,varid,'_FillValue',spval), &
+                        'put att _FillValue for tmask')
         endif
 
         if (igrd(n_blkmask)) then
-           status = nf90_def_var(ncid, 'blkmask', nf90_float, dimid(1:2), varid)
-           if (status /= nf90_noerr) call abort_ice( &
-                         'ice: Error defining var blkmask')
-           status = nf90_put_att(ncid,varid, 'long_name', 'ice grid block mask') 
-           if (status /= nf90_noerr) call abort_ice('ice Error: blkmask long_name') 
-           status = nf90_put_att(ncid, varid, 'coordinates', 'TLON TLAT')
-           if (status /= nf90_noerr) call abort_ice('ice Error: blkmask units') 
-           status = nf90_put_att(ncid,varid,'comment', 'mytask + iblk/100')
-           if (status /= nf90_noerr) call abort_ice('ice Error: blkmask comment') 
-           status = nf90_put_att(ncid,varid,'missing_value',spval)
-           if (status /= nf90_noerr) call abort_ice('Error defining missing_value for blkmask')
-           status = nf90_put_att(ncid,varid,'_FillValue',spval)
-           if (status /= nf90_noerr) call abort_ice('Error defining _FillValue for blkmask')
+            call check(nf90_def_var(ncid, 'blkmask', nf90_float, dimid(1:2), varid), &
+                       'def var blkmask')
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                            (/ history_chunksize_x, history_chunksize_y /)), &
+                           'def var chunking blkmask')
+            endif
+
+            call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level), &
+                       'deflating var blkmask')
+
+            call check(nf90_put_att(ncid,varid, 'long_name', 'ice grid block mask'), &
+                        'put att blkmask long_name')
+            call check(nf90_put_att(ncid, varid, 'coordinates', 'TLON TLAT'), &
+                        'put att blkmask coordinates')
+            call check(nf90_put_att(ncid,varid,'comment', 'mytask + iblk/100'), &
+                        'put att blkmask comment')
+            call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                        'put att blkmask missing_value')
+            call check(nf90_put_att(ncid,varid,'_FillValue',spval), &
+                        'put att blkmask _FillValue')
         endif
 
         do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
           if (igrd(i)) then
-             status = nf90_def_var(ncid, var(i)%req%short_name, &
-                                   nf90_float, dimid(1:2), varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining variable '//var(i)%req%short_name)
-             status = nf90_put_att(ncid,varid, 'long_name', var(i)%req%long_name)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining long_name for '//var(i)%req%short_name)
-             status = nf90_put_att(ncid, varid, 'units', var(i)%req%units)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining units for '//var(i)%req%short_name)
-             status = nf90_put_att(ncid, varid, 'coordinates', var(i)%coordinates)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining coordinates for '//var(i)%req%short_name)
-             status = nf90_put_att(ncid,varid,'missing_value',spval)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining missing_value for '//var(i)%req%short_name)
-             status = nf90_put_att(ncid,varid,'_FillValue',spval)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining _FillValue for '//var(i)%req%short_name)
+                call check(nf90_def_var(ncid, var(i)%req%short_name, &
+                                       nf90_float, dimid(1:2), varid), &
+                           'def variable '//var(i)%req%short_name)
+
+                if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                    call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                                (/ history_chunksize_x, history_chunksize_y /)), &
+                               'def var chunking '//var(i)%req%short_name)
+                endif
+
+                call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                              deflate_level), &
+                           'deflate var '//var(i)%req%short_name)
+
+                call check(nf90_put_att(ncid,varid, 'long_name', var(i)%req%long_name), &
+                           'put att long_name '//var(i)%req%short_name)
+                call check(nf90_put_att(ncid, varid, 'units', var(i)%req%units), &
+                           'put att units '//var(i)%req%short_name)
+                call check(nf90_put_att(ncid, varid, 'coordinates', var(i)%coordinates), &
+                           'put att coordinates '//var(i)%req%short_name)
+                call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                           'put att missing_value '//var(i)%req%short_name)
+                call check(nf90_put_att(ncid,varid,'_FillValue',spval), &
+                           'put att _FillValue '//var(i)%req%short_name)
           endif
         enddo
 
@@ -448,64 +493,75 @@
         dimid_nverts(3) = jmtid
         do i = 1, nvar_verts
           if (f_bounds) then
-             status = nf90_def_var(ncid, var_nverts(i)%short_name, &
-                                   nf90_float,dimid_nverts, varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining variable '//var_nverts(i)%short_name)
-             status = nf90_put_att(ncid,varid, 'long_name', var_nverts(i)%long_name)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining long_name for '//var_nverts(i)%short_name)
-             status = nf90_put_att(ncid, varid, 'units', var_nverts(i)%units)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'Error defining units for '//var_nverts(i)%short_name)
-             status = nf90_put_att(ncid,varid,'missing_value',spval)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining missing_value for '//var_nverts(i)%short_name)
-             status = nf90_put_att(ncid,varid,'_FillValue',spval)
-             if (status /= nf90_noerr) call abort_ice( &
-                'Error defining _FillValue for '//var_nverts(i)%short_name)
+                call check(nf90_def_var(ncid, var_nverts(i)%short_name, &
+                                      nf90_float,dimid_nverts, varid), &
+                           'def var '//var_nverts(i)%short_name)
+
+                if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                    call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                                (/ 1, history_chunksize_x, history_chunksize_y /)), &
+                               'def var chunking '//var_nverts(i)%short_name)
+                endif
+
+                call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                              deflate_level), &
+                           'deflate var '//var_nverts(i)%short_name)
+
+                call check(nf90_put_att(ncid,varid, 'long_name', &
+                            var_nverts(i)%long_name), &
+                           'put att long_name '//var_nverts(i)%short_name)
+                call check(nf90_put_att(ncid, varid, 'units', var_nverts(i)%units), &
+                           'put att units '//var_nverts(i)%short_name)
+                call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                           'put att missing_value '//var_nverts(i)%short_name)
+                call check(nf90_put_att(ncid,varid,'_FillValue',spval), &
+                           'put att _FillValue '//var_nverts(i)%short_name)
           endif
         enddo
 
         do n=1,num_avail_hist_fields_2D
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            status  = nf90_def_var(ncid, avail_hist_fields(n)%vname, &
-                         nf90_float, dimid, varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining variable '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid,'units', &
-                        avail_hist_fields(n)%vunit)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining units for '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid, 'long_name', &
-                        avail_hist_fields(n)%vdesc)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining long_name for '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid,'coordinates', &
-                        avail_hist_fields(n)%vcoord)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining coordinates for '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid,'cell_measures', &
-                        avail_hist_fields(n)%vcellmeas)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining cell measures for '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid,'missing_value',spval)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining missing_value for '//avail_hist_fields(n)%vname)
-            status = nf90_put_att(ncid,varid,'_FillValue',spval)
-            if (status /= nf90_noerr) call abort_ice( &
-               'Error defining _FillValue for '//avail_hist_fields(n)%vname)
+                call check(nf90_def_var(ncid, avail_hist_fields(n)%vname, &
+                                       nf90_float, dimid, varid), &
+                           'def var '//avail_hist_fields(n)%vname)
 
-      !-----------------------------------------------------------------
-      ! Add cell_methods attribute to variables if averaged
-      !-----------------------------------------------------------------
+                if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                    call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                                (/ history_chunksize_x, history_chunksize_y, 1 /)), &
+                               'def var chunking '//avail_hist_fields(n)%vname)
+                endif
+
+                call check(nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                              deflate_level), &
+                           'deflate '//avail_hist_fields(n)%vname)
+
+                call check(nf90_put_att(ncid,varid,'units', &
+                            avail_hist_fields(n)%vunit), &
+                           'put att units '//avail_hist_fields(n)%vname)
+                call check(nf90_put_att(ncid,varid, 'long_name', &
+                            avail_hist_fields(n)%vdesc), &
+                           'put att long_name '//avail_hist_fields(n)%vname)
+                call check(nf90_put_att(ncid,varid,'coordinates', &
+                            avail_hist_fields(n)%vcoord), &
+                           'put att coordinates '//avail_hist_fields(n)%vname)
+                call check(nf90_put_att(ncid,varid,'cell_measures', &
+                            avail_hist_fields(n)%vcellmeas), &
+                           'put att cell_measures '//avail_hist_fields(n)%vname)
+                call check(nf90_put_att(ncid,varid,'missing_value',spval), &
+                           'put att missing_value '//avail_hist_fields(n)%vname)
+                call check(nf90_put_att(ncid,varid,'_FillValue',spval), &
+                           'put att _FillValue '//avail_hist_fields(n)%vname)
+
+                !---------------------------------------------------------------
+                ! Add cell_methods attribute to variables if averaged
+                !---------------------------------------------------------------
             if (hist_avg) then
-              if (TRIM(avail_hist_fields(n)%vname)/='sig1' &
-              .or.TRIM(avail_hist_fields(n)%vname)/='sig2') then
-                status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
-                if (status /= nf90_noerr) call abort_ice( &
-                 'Error defining cell methods for '//avail_hist_fields(n)%vname)
-              endif
+                if (TRIM(avail_hist_fields(n)%vname)/='sig1' .or. &
+                    TRIM(avail_hist_fields(n)%vname)/='sig2') then
+
+                    call check(nf90_put_att(ncid,varid,'cell_methods','time: mean'), &
+                          'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                endif
             endif
 
             if (histfreq(ns) == '1' .or. .not. hist_avg         &
@@ -514,9 +570,11 @@
                 .or. n==n_trsig(ns)                             &
                 .or. n==n_mlt_onset(ns) .or. n==n_frz_onset(ns) &
                 .or. n==n_hisnap(ns)    .or. n==n_aisnap(ns)) then
-               status = nf90_put_att(ncid,varid,'time_rep','instantaneous')
+                    call check(nf90_put_att(ncid,varid,'time_rep','instantaneous'), &
+                               'put att time_rep instantaneous')
             else
-               status = nf90_put_att(ncid,varid,'time_rep','averaged')
+                    call check(nf90_put_att(ncid,varid,'time_rep','averaged'), &
+                               'put att time_rep averaged')
             endif
           endif
         enddo  ! num_avail_hist_fields_2D
@@ -532,6 +590,18 @@
                          nf90_float, dimidz, varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+               call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                           (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                           'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+               'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -555,9 +625,9 @@
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining _FillValue for '//avail_hist_fields(n)%vname)
 
-      !-----------------------------------------------------------------
-      ! Add cell_methods attribute to variables if averaged
-      !-----------------------------------------------------------------
+            !---------------------------------------------------------------
+            ! Add cell_methods attribute to variables if averaged
+            !---------------------------------------------------------------
             if (hist_avg) then
                 status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
                 if (status /= nf90_noerr) call abort_ice( &
@@ -583,6 +653,18 @@
                          nf90_float, dimidz, varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+               call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                           (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                           'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+               'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -620,6 +702,18 @@
                          nf90_float, dimidz, varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+               call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                           (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                           'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+               'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -642,7 +736,6 @@
             status = nf90_put_att(ncid,varid,'_FillValue',spval)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining _FillValue for '//avail_hist_fields(n)%vname)
-
           endif
         enddo  ! num_avail_hist_fields_3Db
 
@@ -655,10 +748,22 @@
         do n = n3Dbcum + 1, n4Dicum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = nf90_def_var(ncid, avail_hist_fields(n)%vname, &
-!                             nf90_float, dimidcz, varid)
-                             nf90_float, dimidcz(1:4), varid) ! ferret    
+                                       !nf90_float, dimidcz, varid)  ! ferret
+                                       nf90_float, dimidcz(1:4), varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+               call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                           (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                           'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+               'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -682,9 +787,9 @@
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining _FillValue for '//avail_hist_fields(n)%vname)
 
-      !-----------------------------------------------------------------
-      ! Add cell_methods attribute to variables if averaged
-      !-----------------------------------------------------------------
+            !---------------------------------------------------------------
+            ! Add cell_methods attribute to variables if averaged
+            !---------------------------------------------------------------
             if (hist_avg) then
                 status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
                 if (status /= nf90_noerr) call abort_ice( &
@@ -708,10 +813,22 @@
         do n = n4Dicum + 1, n4Dscum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = nf90_def_var(ncid, avail_hist_fields(n)%vname, &
-!                             nf90_float, dimidcz, varid)
-                             nf90_float, dimidcz(1:4), varid) ! ferret    
+                                       !nf90_float, dimidcz, varid) ! ferret
+                                       nf90_float, dimidcz(1:4), varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+               call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                           (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                           'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+               'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -735,9 +852,9 @@
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining _FillValue for '//avail_hist_fields(n)%vname)
 
-      !-----------------------------------------------------------------
-      ! Add cell_methods attribute to variables if averaged
-      !-----------------------------------------------------------------
+            !---------------------------------------------------------------
+            ! Add cell_methods attribute to variables if averaged
+            !---------------------------------------------------------------
             if (hist_avg) then
                 status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
                 if (status /= nf90_noerr) call abort_ice( &
@@ -761,10 +878,22 @@
         do n = n4Dscum + 1, n4Dbcum
           if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
             status  = nf90_def_var(ncid, avail_hist_fields(n)%vname, &
-!                             nf90_float, dimidcz, varid)
-                             nf90_float, dimidcz(1:4), varid) ! ferret    
+                                       !nf90_float, dimidcz, varid) ! ferret
+                                       nf90_float, dimidcz(1:4), varid)
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining variable '//avail_hist_fields(n)%vname)
+
+            if (history_chunksize_x > 0 .and. history_chunksize_y > 0) then
+                call check(nf90_def_var_chunking(ncid, varid, NF90_CHUNKED, &
+                            (/ history_chunksize_x, history_chunksize_y, 1, 1 /)), &
+                            'def var chunking '//avail_hist_fields(n)%vname)
+            endif
+
+            status = nf90_def_var_deflate(ncid, varid, shuffle, deflate, &
+                                          deflate_level)
+            if (status /= nf90_noerr) call abort_ice( &
+                'Error deflating variable '//avail_hist_fields(n)%vname)
+
             status = nf90_put_att(ncid,varid,'units', &
                         avail_hist_fields(n)%vunit)
             if (status /= nf90_noerr) call abort_ice( &
@@ -788,9 +917,9 @@
             if (status /= nf90_noerr) call abort_ice( &
                'Error defining _FillValue for '//avail_hist_fields(n)%vname)
 
-      !-----------------------------------------------------------------
-      ! Add cell_methods attribute to variables if averaged
-      !-----------------------------------------------------------------
+            !---------------------------------------------------------------
+            ! Add cell_methods attribute to variables if averaged
+            !---------------------------------------------------------------
             if (hist_avg) then
                 status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
                 if (status /= nf90_noerr) call abort_ice( &
@@ -798,9 +927,11 @@
             endif
 
             if (histfreq(ns) == '1' .or. .not. hist_avg) then
-               status = nf90_put_att(ncid,varid,'time_rep','instantaneous')
+                call check(nf90_put_att(ncid,varid,'time_rep','instantaneous'), &
+                          'put att time_rep instantaneous')
             else
-               status = nf90_put_att(ncid,varid,'time_rep','averaged')
+                call check(nf90_put_att(ncid,varid,'time_rep','averaged'), &
+                          'put att time_rep averaged')
             endif
           endif
         enddo  ! num_avail_hist_fields_4Db
@@ -811,49 +942,41 @@
       ! ... the user should change these to something useful ...
       !-----------------------------------------------------------------
 #ifdef CCSMCOUPLED
-        status = nf90_put_att(ncid,nf90_global,'title',runid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error in global attribute title')
+        call check(nf90_put_att(ncid,nf90_global,'title',runid), &
+                   'in global attribute title')
 #else
         title  = 'sea ice model output for CICE'
-        status = nf90_put_att(ncid,nf90_global,'title',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error in global attribute title')
+        call check(nf90_put_att(ncid,nf90_global,'title',title), &
+                   'global attribute title')
 #endif
         title = 'Diagnostic and Prognostic Variables'
-        status = nf90_put_att(ncid,nf90_global,'contents',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute contents')
+        call check(nf90_put_att(ncid,nf90_global,'contents',title), &
+                  'global attribute contents')
 
         title  = 'Los Alamos Sea Ice Model (CICE) Version 5'
-        status = nf90_put_att(ncid,nf90_global,'source',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute source')
+        call check(nf90_put_att(ncid,nf90_global,'source',title), &
+                   'global attribute source')
 
         if (use_leap_years) then
           write(title,'(a,i3,a)') 'This year has ',int(dayyr),' days'
         else
           write(title,'(a,i3,a)') 'All years have exactly ',int(dayyr),' days'
         endif
-        status = nf90_put_att(ncid,nf90_global,'comment',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute comment')
+#endif
+        call check(nf90_put_att(ncid,nf90_global,'comment',title), &
+                   'global attribute comment')
 
         write(title,'(a,i8.8)') 'File written on model date ',idate
-        status = nf90_put_att(ncid,nf90_global,'comment2',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute date1')
+        call check(nf90_put_att(ncid,nf90_global,'comment2',title), &
+                   'global attribute comment2')
 
         write(title,'(a,i6)') 'seconds elapsed into model date: ',sec
-        status = nf90_put_att(ncid,nf90_global,'comment3',title)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute date2')
+        call check(nf90_put_att(ncid,nf90_global,'comment3',title), &
+                   'global attribute comment3')
 
         title = 'CF-1.0'
-        status =  &
-             nf90_put_att(ncid,nf90_global,'conventions',title)
-        if (status /= nf90_noerr) call abort_ice( &
-             'Error in global attribute conventions')
+        call check(nf90_put_att(ncid,nf90_global,'conventions',title), &
+                   'global attribute conventions')
 
         call date_and_time(date=current_date, time=current_time)
         write(start_time,1000) current_date(1:4), current_date(5:6), &
@@ -862,67 +985,118 @@
 1000    format('This dataset was created on ', &
                 a,'-',a,'-',a,' at ',a,':',a,':',a)
 
-        status = nf90_put_att(ncid,nf90_global,'history',start_time)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute history')
+        call check(nf90_put_att(ncid,nf90_global,'history',start_time), &
+                   'global attribute history')
 
-        status = nf90_put_att(ncid,nf90_global,'io_flavor','io_netcdf')
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice Error: global attribute io_flavor')
+        call check(nf90_put_att(ncid,nf90_global,'io_flavor','io_netcdf'), &
+                   'global attribute io_flavor')
 
       !-----------------------------------------------------------------
       ! end define mode
       !-----------------------------------------------------------------
 
-        status = nf90_enddef(ncid)
-        if (status /= nf90_noerr) call abort_ice('ice: Error in nf90_enddef')
+        call check(nf90_enddef(ncid), 'enddef')
 
       !-----------------------------------------------------------------
       ! write time variable
       !-----------------------------------------------------------------
 
-        status = nf90_inq_varid(ncid,'time',varid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error getting time varid')
-        status = nf90_put_var(ncid,varid,ltime)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error writing time variable')
+        call check(nf90_inq_varid(ncid,'time',varid), &
+                   'inq varid time')
+        call check(nf90_put_var(ncid,varid,ltime), &
+                   'put var time')
 
       !-----------------------------------------------------------------
       ! write time_bounds info
       !-----------------------------------------------------------------
 
         if (hist_avg) then
-          status = nf90_inq_varid(ncid,'time_bounds',varid)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error getting time_bounds id')
-          status = nf90_put_var(ncid,varid,time_beg(ns),start=(/1/))
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error writing time_beg')
-          status = nf90_put_var(ncid,varid,time_end(ns),start=(/2/))
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error writing time_end')
+            call check(nf90_inq_varid(ncid,'time_bounds',varid), &
+                       'inq varid time_bounds')
+            call check(nf90_put_var(ncid,varid,time_beg(ns),start=(/1/)), &
+                       'put var time_bounds beginning')
+            call check(nf90_put_var(ncid,varid,time_end(ns),start=(/2/)), &
+                       'put var time_bounds end')
         endif
+    endif                     ! master_task or history_parallel_io
 
-      endif                     ! master_task
+    !-----------------------------------------------------------------
+    ! write coordinate variables
+    !-----------------------------------------------------------------
+
+    if (history_parallel_io) then
+        call write_coordinate_variables_parallel(ncid, coord_var, var_nz)
+    else
+        call write_coordinate_variables(ncid, coord_var, var_nz)
+    endif
+
+    !-----------------------------------------------------------------
+    ! write grid masks, area and rotation angle
+    !-----------------------------------------------------------------
+
+    if (history_parallel_io) then
+        call write_grid_variables_parallel(ncid, var, var_nverts)
+    else
+        call write_grid_variables(ncid, var, var_nverts)
+    endif
+
+
+    !-----------------------------------------------------------------
+    ! write 2d variable data
+    !-----------------------------------------------------------------
+
+    if (history_parallel_io) then
+        call write_2d_variables_parallel(ns, ncid)
+    else
+        call write_2d_variables(ns, ncid)
+    endif
+
+    if (history_parallel_io) then
+        call write_3d_and_4d_variables_parallel(ns, ncid)
+    else
+        call write_3d_and_4d_variables(ns, ncid)
+    endif
+
+    !-----------------------------------------------------------------
+    ! close output dataset
+    !-----------------------------------------------------------------
+
+    if (my_task == master_task .or. history_parallel_io) then
+        call check(nf90_close(ncid), 'closing netCDF history file')
+        write(nu_diag,*) ' '
+        write(nu_diag,*) 'Finished writing ',trim(ncfile(ns))
+    endif
+
+end subroutine ice_write_hist
+
+subroutine write_coordinate_variables(ncid, coord_var, var_nz)
+
+    integer, intent(in) :: ncid
+    type(coord_attributes), dimension(ncoord), intent(in) :: coord_var
+    type(coord_attributes), dimension(nvarz) :: var_nz
+
+    real (kind=dbl_kind),  dimension(:,:),   allocatable :: work_g1
+    real (kind=real_kind), dimension(:,:),   allocatable :: work_gr
+    real (kind=dbl_kind),  dimension(nx_block,ny_block,max_blocks) :: work1
+
+    integer :: i, k, status
+    integer :: varid
+    character (len=len(coord_var(1)%short_name)) :: coord_var_name
 
       if (my_task==master_task) then
          allocate(work_g1(nx_global,ny_global))
          allocate(work_gr(nx_global,ny_global))
       else
-         allocate(work_gr(1,1))   ! to save memory
          allocate(work_g1(1,1))
+         allocate(work_gr(1,1))   ! to save memory
       endif
 
       work_g1(:,:) = c0
 
-      !-----------------------------------------------------------------
-      ! write coordinate variables
-      !-----------------------------------------------------------------
-
         do i = 1,ncoord
-          call broadcast_scalar(coord_var(i)%short_name,master_task)
-          SELECT CASE (coord_var(i)%short_name)
+        coord_var_name = coord_var(i)%short_name
+        call broadcast_scalar(coord_var_name, master_task)
+        SELECT CASE (coord_var_name)
             CASE ('TLON')
               ! Convert T grid longitude from -180 -> 180 to 0 to 360
               work1 = TLON*rad_to_deg + c360
@@ -942,12 +1116,10 @@
           
           if (my_task == master_task) then
              work_gr = work_g1
-             status = nf90_inq_varid(ncid, coord_var(i)%short_name, varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'ice: Error getting varid for '//coord_var(i)%short_name)
-             status = nf90_put_var(ncid,varid,work_gr)
-             if (status /= nf90_noerr) call abort_ice( &
-                           'ice: Error writing'//coord_var(i)%short_name)
+            call check(nf90_inq_varid(ncid, coord_var_name, varid), &
+                        'inq varid '//coord_var_name)
+            call check(nf90_put_var(ncid,varid,work_gr), &
+                        'put var '//coord_var_name)
           endif
         enddo
 
@@ -957,9 +1129,8 @@
           if (igrdz(i)) then
           call broadcast_scalar(var_nz(i)%short_name,master_task)
           if (my_task == master_task) then
-             status = nf90_inq_varid(ncid, var_nz(i)%short_name, varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                  'ice: Error getting varid for '//var_nz(i)%short_name)
+            call check(nf90_inq_varid(ncid, var_nz(i)%short_name, varid), &
+                     'inq varid '//var_nz(i)%short_name)
              SELECT CASE (var_nz(i)%short_name)
                CASE ('NCAT') 
                  status = nf90_put_var(ncid,varid,hin_max(1:ncat_hist))
@@ -976,20 +1147,51 @@
           endif
         enddo
 
-      !-----------------------------------------------------------------
-      ! write grid masks, area and rotation angle
-      !-----------------------------------------------------------------
+    deallocate(work_g1)
+    deallocate(work_gr)
+
+end subroutine write_coordinate_variables
+
+
+
+subroutine write_grid_variables(ncid, var, var_nverts)
+
+    integer, intent(in) :: ncid
+    type(req_attributes), dimension(nvar), intent(in) :: var
+    type(coord_attributes), dimension(nvar_verts), intent(in) :: var_nverts
+
+    real (kind=dbl_kind),  dimension(:,:), allocatable :: work_g1
+    real (kind=real_kind), dimension(:,:), allocatable :: work_gr
+    real (kind=real_kind), dimension(:,:, :), allocatable :: work_gr3
+    real (kind=dbl_kind),  dimension(nx_block,ny_block,max_blocks) :: work1
+
+    integer :: ivertex, i
+    integer :: varid
+    character (len=len(var(1)%req%short_name)) :: var_name
+    character (len=len(var_nverts(1)%short_name)) :: var_nverts_name
+
+    if (my_task == master_task) then
+        allocate(work_g1(nx_global,ny_global))
+        allocate(work_gr(nx_global,ny_global))
+        allocate(work_gr3(nverts,nx_global,ny_global))
+    else
+        allocate(work_g1(1,1))
+        allocate(work_gr(1,1))   ! to save memory
+        allocate(work_gr3(1,1,1))
+    endif
+
+    work_g1(:,:) = c0
+    work_gr(:,:) = c0
+    work_gr3(:,:,:) = c0
 
       if (igrd(n_tmask)) then
       call gather_global(work_g1, hm, master_task, distrb_info)
       if (my_task == master_task) then
-        work_gr=work_g1
-        status = nf90_inq_varid(ncid, 'tmask', varid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error getting varid for tmask')
-        status = nf90_put_var(ncid,varid,work_gr)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error writing variable tmask')
+            work_gr = work_g1
+            call check(nf90_inq_varid(ncid, 'tmask', varid), &
+                       'inq var tmask')
+            call check(nf90_put_var(ncid,varid,work_gr), &
+                       'put var blkmask')
       endif
       endif
 
@@ -997,19 +1199,19 @@
       call gather_global(work_g1, bm, master_task, distrb_info)
       if (my_task == master_task) then
         work_gr=work_g1
-        status = nf90_inq_varid(ncid, 'blkmask', varid)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error getting varid for blkmask')
-        status = nf90_put_var(ncid,varid,work_gr)
-        if (status /= nf90_noerr) call abort_ice( &
-                      'ice: Error writing variable blkmask')
+            call check(nf90_inq_varid(ncid, 'blkmask', varid), &
+                       'inq var blkmask')
+            call check(nf90_put_var(ncid,varid,work_gr), &
+                       'put var blkmask')
       endif
       endif
 
       do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
         if (igrd(i)) then
-        call broadcast_scalar(var(i)%req%short_name,master_task)
-        SELECT CASE (var(i)%req%short_name)
+            var_name = var(i)%req%short_name
+
+            call broadcast_scalar(var_name,master_task)
+            SELECT CASE (var_name)
           CASE ('tarea')
             call gather_global(work_g1, tarea, master_task, distrb_info)
           CASE ('uarea')
@@ -1034,35 +1236,26 @@
 
         if (my_task == master_task) then
           work_gr=work_g1
-          status = nf90_inq_varid(ncid, var(i)%req%short_name, varid)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error getting varid for '//var(i)%req%short_name)
-          status = nf90_put_var(ncid,varid,work_gr)
-          if (status /= nf90_noerr) call abort_ice( &
-                        'ice: Error writing variable '//var(i)%req%short_name)
+              call check(nf90_inq_varid(ncid, var_name, varid), &
+                         'inq varid  '//var_name)
+              call check(nf90_put_var(ncid,varid,work_gr), &
+                         'put var '//var_name)
         endif
         endif
       enddo
-
-      deallocate(work_gr)
 
       !----------------------------------------------------------------
       ! Write coordinates of grid box vertices
       !----------------------------------------------------------------
 
       if (f_bounds) then
-      if (my_task==master_task) then
-         allocate(work_gr3(nverts,nx_global,ny_global))
-      else
-         allocate(work_gr3(1,1,1))   ! to save memory
-      endif
-
       work_gr3(:,:,:) = c0
       work1   (:,:,:) = c0
 
       do i = 1, nvar_verts
-        call broadcast_scalar(var_nverts(i)%short_name,master_task)
-        SELECT CASE (var_nverts(i)%short_name)
+            var_nverts_name = var_nverts(i)%short_name
+            call broadcast_scalar(var_nverts_name,master_task)
+            SELECT CASE (var_nverts_name)
         CASE ('lont_bounds')
         do ivertex = 1, nverts 
            work1(:,:,:) = lont_bounds(ivertex,:,:,:)
@@ -1090,45 +1283,82 @@
         END SELECT
 
         if (my_task == master_task) then
-          status = nf90_inq_varid(ncid, var_nverts(i)%short_name, varid)
-          if (status /= nf90_noerr) call abort_ice( &
-             'ice: Error getting varid for '//var_nverts(i)%short_name)
-          status = nf90_put_var(ncid,varid,work_gr3)
-          if (status /= nf90_noerr) call abort_ice( &
-             'ice: Error writing variable '//var_nverts(i)%short_name)
+                call check(nf90_inq_varid(ncid, var_nverts_name, varid), &
+                            'inq varid '//var_nverts_name)
+                call check(nf90_put_var(ncid,varid,work_gr3), &
+                            'put var '//var_nverts_name)
         endif
       enddo
-      deallocate(work_gr3)
       endif
 
-      !-----------------------------------------------------------------
-      ! write variable data
-      !-----------------------------------------------------------------
+    deallocate(work_g1)
+    deallocate(work_gr)
+    deallocate(work_gr3)
 
-      if (my_task==master_task) then
+end subroutine write_grid_variables
+
+
+subroutine write_2d_variables(ns, ncid)
+
+    integer, intent(in) :: ns
+    integer, intent(in) :: ncid
+
+    real (kind=dbl_kind),  dimension(:,:), allocatable :: work_g1
+    real (kind=real_kind), dimension(:,:), allocatable :: work_gr
+
+    integer :: n
+    integer :: varid
+
+    if (my_task == master_task) then
+       allocate(work_g1(nx_global,ny_global))
          allocate(work_gr(nx_global,ny_global))
       else
+       allocate(work_g1(1,1))
          allocate(work_gr(1,1))     ! to save memory
       endif
+
       work_gr(:,:) = c0
       work_g1(:,:) = c0
 
-      do n=1,num_avail_hist_fields_2D
+    do n=1, num_avail_hist_fields_2D
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           call gather_global(work_g1, a2D(:,:,n,:), &
                              master_task, distrb_info)
           if (my_task == master_task) then
             work_gr(:,:) = work_g1(:,:)
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-            status  = nf90_put_var(ncid,varid,work_gr(:,:), &
-                                   count=(/nx_global,ny_global/))
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
+                call check(nf90_put_var(ncid,varid,work_gr(:,:), &
+                                        count=(/nx_global,ny_global/)), &
+                            'put var '//avail_hist_fields(n)%vname)
           endif
         endif
       enddo ! num_avail_hist_fields_2D
+
+    deallocate(work_g1)
+    deallocate(work_gr)
+
+end subroutine write_2d_variables
+
+
+subroutine write_3d_and_4d_variables(ns, ncid)
+
+    integer, intent(in) :: ns
+    integer, intent(in) :: ncid
+
+    real (kind=dbl_kind),  dimension(:,:), allocatable :: work_g1
+    real (kind=real_kind), dimension(:,:), allocatable :: work_gr
+
+    integer :: varid
+    integer :: n, nn, k, ic
+
+    if (my_task == master_task) then
+       allocate(work_g1(nx_global,ny_global))
+       allocate(work_gr(nx_global,ny_global))
+    else
+       allocate(work_g1(1,1))
+       allocate(work_gr(1,1))     ! to save memory
+    endif
 
       work_gr(:,:) = c0
       work_g1(:,:) = c0
@@ -1137,9 +1367,8 @@
         nn = n - n2D
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
           endif
           do k = 1, ncat_hist
              call gather_global(work_g1, a3Dc(:,:,k,nn,:), &
@@ -1147,14 +1376,10 @@
              work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-             if (status /= nf90_noerr) call abort_ice( &
-                'ice: Error getting varid for '//avail_hist_fields(n)%vname)
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
-                                    start=(/        1,        1,k/), &
-                                    count=(/nx_global,ny_global,1/))
-             if (status /= nf90_noerr) call abort_ice( &
-                'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                    call check(nf90_put_var(ncid,varid,work_gr(:,:), &
+                                            start=(/        1,        1, k/), &
+                                            count=(/nx_global,ny_global, 1/)), &
+                               'put var '//avail_hist_fields(n)%vname)
              endif
           enddo ! k
         endif
@@ -1167,9 +1392,8 @@
         nn = n - n3Dccum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
           endif
           do k = 1, nzilyr
              call gather_global(work_g1, a3Dz(:,:,k,nn,:), &
@@ -1177,11 +1401,10 @@
              work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                    call check(nf90_put_var(ncid,varid,work_gr(:,:), &
                                     start=(/        1,        1,k/), &
-                                    count=(/nx_global,ny_global,1/))
-             if (status /= nf90_noerr) call abort_ice( &
-                'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                                            count=(/nx_global,ny_global,1/)), &
+                               'put var '//avail_hist_fields(n)%vname)
            endif
            enddo ! k
         endif
@@ -1194,9 +1417,8 @@
         nn = n - n3Dzcum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
           endif
           do k = 1, nzblyr
              call gather_global(work_g1, a3Db(:,:,k,nn,:), &
@@ -1204,11 +1426,10 @@
              work_gr(:,:) = work_g1(:,:)
 
              if (my_task == master_task) then
-             status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                    call check(nf90_put_var(ncid,varid,work_gr(:,:),    &
                                     start=(/        1,        1,k/), &
-                                    count=(/nx_global,ny_global,1/))
-             if (status /= nf90_noerr) call abort_ice( &
-                'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                                            count=(/nx_global,ny_global,1/)), &
+                               'put var '//avail_hist_fields(n)%vname)
            endif
            enddo ! k
         endif
@@ -1221,9 +1442,8 @@
         nn = n - n3Dbcum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
           endif
           do ic = 1, ncat_hist
              do k = 1, nzilyr
@@ -1231,11 +1451,10 @@
                                 master_task, distrb_info)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                        call check(nf90_put_var(ncid,varid,work_gr(:,:), &
                                          start=(/        1,        1,k,ic/), &
-                                         count=(/nx_global,ny_global,1, 1/))
-                  if (status /= nf90_noerr) call abort_ice( &
-                     'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                                                count=(/nx_global,ny_global,1, 1/)), &
+                                   'put var '//avail_hist_fields(n)%vname)
                 endif
              enddo ! k
           enddo ! ic
@@ -1249,9 +1468,8 @@
         nn = n - n4Dicum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq var '//avail_hist_fields(n)%vname)
           endif
           do ic = 1, ncat_hist
              do k = 1, nzslyr
@@ -1259,11 +1477,10 @@
                                 master_task, distrb_info)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                        call check(nf90_put_var(ncid,varid,work_gr(:,:), &
                                          start=(/        1,        1,k,ic/), &
-                                         count=(/nx_global,ny_global,1, 1/))
-                  if (status /= nf90_noerr) call abort_ice( &
-                     'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                                                count=(/nx_global,ny_global,1, 1/)), &
+                                  'put var '//avail_hist_fields(n)%vname)
                 endif
              enddo ! k
           enddo ! ic
@@ -1277,9 +1494,8 @@
         nn = n - n4Dscum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
           if (my_task == master_task) then
-            status  = nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid)
-            if (status /= nf90_noerr) call abort_ice( &
-               'ice: Error getting varid for '//avail_hist_fields(n)%vname)
+                call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
+                           'inq varid '//avail_hist_fields(n)%vname)
           endif
           do ic = 1, ncat_hist
              do k = 1, nzblyr
@@ -1287,11 +1503,10 @@
                                 master_task, distrb_info)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
-                  status  = nf90_put_var(ncid,varid,work_gr(:,:), &
+                        call check(nf90_put_var(ncid,varid,work_gr(:,:), &
                                          start=(/        1,        1,k,ic/), &
-                                         count=(/nx_global,ny_global,1, 1/))
-                  if (status /= nf90_noerr) call abort_ice( &
-                     'ice: Error writing variable '//avail_hist_fields(n)%vname)
+                                                count=(/nx_global,ny_global,1, 1/)), &
+                                   'put var '//avail_hist_fields(n)%vname)
                 endif
              enddo ! k
           enddo ! ic
@@ -1301,23 +1516,354 @@
       deallocate(work_gr)
       deallocate(work_g1)
 
-      !-----------------------------------------------------------------
-      ! close output dataset
-      !-----------------------------------------------------------------
+end subroutine write_3d_and_4d_variables
 
-      if (my_task == master_task) then
-         status = nf90_close(ncid)
-         if (status /= nf90_noerr) call abort_ice( &
-                       'ice: Error closing netCDF history file')
-         write(nu_diag,*) ' '
-         write(nu_diag,*) 'Finished writing ',trim(ncfile(ns))
+
+subroutine write_coordinate_variables_parallel(ncid, coord_var, var_nz)
+
+    integer, intent(in) :: ncid
+    type(coord_attributes), dimension(ncoord), intent(in) :: coord_var
+    type(coord_attributes), dimension(nvarz) :: var_nz
+
+    integer :: varid
+    integer :: iblk, i, k
+    real(kind=dbl_kind), dimension(nx_block,ny_block, max_blocks) :: work1
+
+    do i = 1,ncoord
+        SELECT CASE (coord_var(i)%short_name)
+        CASE ('TLON')
+            ! Convert T grid longitude from -180 -> 180 to 0 to 360
+            work1 = TLON*rad_to_deg + c360
+            where (work1 > c360) work1 = work1 - c360
+            where (work1 < c0 )  work1 = work1 + c360
+        CASE ('TLAT')
+            work1 = TLAT*rad_to_deg
+        CASE ('ULON')
+            work1 = ULON*rad_to_deg
+        CASE ('ULAT')
+            work1 = ULAT*rad_to_deg
+        END SELECT
+
+        call put_2d_with_blocks(ncid, coord_var(i)%short_name, work1)
+    enddo
+
+    ! Extra dimensions (NCAT, VGRD*)
+    do i = 1, nvarz
+        if (igrdz(i)) then
+            call check(nf90_inq_varid(ncid, var_nz(i)%short_name, varid), &
+                        'inq_varid '//var_nz(i)%short_name)
+            SELECT CASE (var_nz(i)%short_name)
+            CASE ('NCAT')
+                call check(nf90_put_var(ncid, varid, hin_max(1:ncat_hist)), &
+                            'put var NCAT')
+            CASE ('VGRDi') ! index - needed for Met Office analysis code
+                call check(nf90_put_var(ncid, varid, (/(k, k=1, nzilyr)/)), &
+                            'put var VGRDi')
+            CASE ('VGRDs') ! index - needed for Met Office analysis code
+                call check(nf90_put_var(ncid, varid, (/(k, k=1, nzslyr)/)), &
+                            'put var VGRDs')
+            CASE ('VGRDb')
+                call check(nf90_put_var(ncid, varid, (/(k, k=1, nzblyr)/)), &
+                            'put var VGRDb')
+            END SELECT
       endif
-#endif
+    enddo
 
-      end subroutine ice_write_hist
+end subroutine write_coordinate_variables_parallel
 
-!=======================================================================
+
+subroutine write_grid_variables_parallel(ncid, var, var_nverts)
+
+    integer, intent(in) :: ncid
+    type(req_attributes), dimension(nvar), intent(in) :: var
+    type(coord_attributes), dimension(nvar_verts), intent(in) :: var_nverts
+
+    real (kind=dbl_kind),  dimension(nx_block, ny_block, max_blocks) :: work1
+    real (kind=dbl_kind),  dimension(nverts, nx_block, ny_block, max_blocks) :: work2
+
+    integer :: iblk
+    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
+    integer, dimension(3) :: start, count
+    type(block) :: the_block
+
+    integer :: i
+    integer :: varid
+
+    if (igrd(n_tmask)) then
+        call put_2d_with_blocks(ncid, 'tmask', hm)
+    endif
+
+    if (igrd(n_blkmask)) then
+        call put_2d_with_blocks(ncid, 'blkmask', bm)
+    endif
+
+    do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
+        if (igrd(i)) then
+            SELECT CASE (var(i)%req%short_name)
+            CASE ('tarea')
+                work1 = tarea
+            CASE ('uarea')
+                work1 = uarea
+            CASE ('dxu')
+                work1 = dxu
+            CASE ('dyu')
+                work1 = dyu
+            CASE ('dxt')
+                work1 = dxt
+            CASE ('dyt')
+                work1 = dyt
+            CASE ('HTN')
+                work1 = HTN
+            CASE ('HTE')
+                work1 = HTE
+            CASE ('ANGLE')
+                work1 = ANGLE
+            CASE ('ANGLET')
+                work1 = ANGLET
+            END SELECT
+
+            call put_2d_with_blocks(ncid, var(i)%req%short_name, work1)
+        endif
+    enddo
+
+    !----------------------------------------------------------------
+    ! Write coordinates of grid box vertices
+    !----------------------------------------------------------------
+
+    if (f_bounds) then
+        do i = 1, nvar_verts
+            SELECT CASE (var_nverts(i)%short_name)
+            CASE ('lont_bounds')
+                work2(:, :, :, :) = lont_bounds(:, :, :, :)
+            CASE ('latt_bounds')
+                work2(:, :, :, :) = latt_bounds(:, :, :, :)
+            CASE ('lonu_bounds')
+                work2(:, :, :, :) = lonu_bounds(:, :, :, :)
+            CASE ('latu_bounds')
+                work2(:, :, :, :) = lonu_bounds(:, :, :, :)
+            END SELECT
+
+            call check(nf90_inq_varid(ncid, var_nverts(i)%short_name, varid), &
+                       'inq varid '//var_nverts(i)%short_name)
+
+            do iblk=1, nblocks
+                the_block = get_block(blocks_ice(iblk), iblk)
+                ilo = the_block%ilo
+                jlo = the_block%jlo
+                ihi = the_block%ihi
+                jhi = the_block%jhi
+
+                gilo = the_block%i_glob(ilo)
+                gjlo = the_block%j_glob(jlo)
+                gihi = the_block%i_glob(ihi)
+                gjhi = the_block%j_glob(jhi)
+
+                start = (/ 1, gilo, gjlo /)
+                count = (/ nverts, gihi - gilo + 1, gjhi - gjlo + 1 /)
+                call check(nf90_put_var(ncid, varid, &
+                                        work2(1:nverts, ilo:ihi, jlo:jhi, iblk), &
+                                        start=start, count=count), &
+                            'grid vars _put '//trim(var_nverts(i)%short_name))
+            enddo
+        enddo
+    endif
+
+end subroutine write_grid_variables_parallel
+
+
+subroutine write_2d_variables_parallel(ns, ncid)
+
+    integer, intent(in) :: ns
+    integer, intent(in) :: ncid
+
+    integer :: varid
+    integer :: n
+
+    do n=1, num_avail_hist_fields_2D
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_2d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    a2D(:, :, n, :))
+        endif
+    enddo ! num_avail_hist_fields_2D
+
+end subroutine write_2d_variables_parallel
+
+
+
+subroutine write_3d_and_4d_variables_parallel(ns, ncid)
+
+    integer, intent(in) :: ns
+    integer, intent(in) :: ncid
+
+    integer :: varid
+    integer :: n, nn, k, ic
+
+    do n = n2D + 1, n3Dccum
+        nn = n - n2D
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    ncat_hist, a3Dc(:, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_3Dc
+
+
+    do n = n3Dccum+1, n3Dzcum
+        nn = n - n3Dccum
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    nzilyr, a3Dz(:, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_3Dz
+
+
+    do n = n3Dzcum+1, n3Dbcum
+        nn = n - n3Dzcum
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    nzblyr, a3Db(:, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_3Db
+
+
+    do n = n3Dbcum+1, n4Dicum
+        nn = n - n3Dbcum
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    nzilyr, ncat_hist, a4Di(:, :, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_4Di
+
+
+    do n = n4Dicum+1, n4Dscum
+        nn = n - n4Dicum
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    nzslyr, ncat_hist, a4Ds(:, :, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_4Ds
+
+    do n = n4Dscum+1, n4Dbcum
+        nn = n - n4Dscum
+        if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
+            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+                                    nzblyr, ncat_hist, a4Db(:, :, :, :, nn, :))
+        endif
+    enddo ! num_avail_hist_fields_4Db
+
+end subroutine write_3d_and_4d_variables_parallel
+
+
+subroutine put_2d_with_blocks(ncid, var_name, data)
+
+    integer, intent(in) :: ncid
+    character(len=*), intent(in) :: var_name
+    real(kind=dbl_kind), dimension(nx_block, ny_block, max_blocks), intent(in) :: data
+
+    integer :: varid
+    integer :: iblk
+    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
+    integer, dimension(2) :: start, count
+    type(block) :: the_block
+
+    call check(nf90_inq_varid(ncid, var_name, varid), &
+               'inq varid for '//var_name)
+
+    do iblk=1, nblocks
+        the_block = get_block(blocks_ice(iblk), iblk)
+        ilo = the_block%ilo
+        jlo = the_block%jlo
+        ihi = the_block%ihi
+        jhi = the_block%jhi
+
+        gilo = the_block%i_glob(ilo)
+        gjlo = the_block%j_glob(jlo)
+        gihi = the_block%i_glob(ihi)
+        gjhi = the_block%j_glob(jhi)
+
+        start = (/ gilo, gjlo /)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1 /)
+        call check(nf90_put_var(ncid, varid, real(data(ilo:ihi, jlo:jhi, iblk)), &
+                                start=start, count=count), &
+                    'put_2d_with_blocks put '//trim(var_name))
+    enddo
+
+end subroutine put_2d_with_blocks
+
+subroutine put_3d_with_blocks(ncid, var_name, len_3dim, data)
+
+    integer, intent(in) :: ncid, len_3dim
+    character(len=*), intent(in) :: var_name
+    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, max_blocks), intent(in) :: data
+
+    integer :: varid
+    integer :: iblk
+    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
+    integer, dimension(3) :: start, count
+    type(block) :: the_block
+
+    call check(nf90_inq_varid(ncid, var_name, varid), &
+               'inq varid for '//var_name)
+
+    do iblk=1, nblocks
+        the_block = get_block(blocks_ice(iblk), iblk)
+        ilo = the_block%ilo
+        jlo = the_block%jlo
+        ihi = the_block%ihi
+        jhi = the_block%jhi
+
+        gilo = the_block%i_glob(ilo)
+        gjlo = the_block%j_glob(jlo)
+        gihi = the_block%i_glob(ihi)
+        gjhi = the_block%j_glob(jhi)
+
+        start = (/ gilo, gjlo, 1 /)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim /)
+        call check(nf90_put_var(ncid, varid, &
+                                real(data(ilo:ihi, jlo:jhi, 1:len_3dim, iblk)), &
+                                start=start, count=count), &
+                    'put_3d_with_blocks put '//trim(var_name))
+    enddo
+
+end subroutine put_3d_with_blocks
+
+
+subroutine put_4d_with_blocks(ncid, var_name, len_3dim, len_4dim, data)
+
+    integer, intent(in) :: ncid, len_3dim, len_4dim
+    character(len=*), intent(in) :: var_name
+    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, &
+                                   len_4dim, max_blocks), intent(in) :: data
+
+    integer :: varid
+    integer :: iblk
+    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
+    integer, dimension(4) :: start, count
+    type(block) :: the_block
+
+    call check(nf90_inq_varid(ncid, var_name, varid), &
+               'inq varid for '//var_name)
+
+    do iblk=1, nblocks
+        the_block = get_block(blocks_ice(iblk), iblk)
+        ilo = the_block%ilo
+        jlo = the_block%jlo
+        ihi = the_block%ihi
+        jhi = the_block%jhi
+
+        gilo = the_block%i_glob(ilo)
+        gjlo = the_block%j_glob(jlo)
+        gihi = the_block%i_glob(ihi)
+        gjhi = the_block%j_glob(jhi)
+
+        start = (/ gilo, gjlo, 1, 1 /)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim, len_4dim /)
+        call check(nf90_put_var(ncid, varid, &
+                                real(data(ilo:ihi, jlo:jhi, 1:len_3dim, 1:len_4dim, iblk)), &
+                                start=start, count=count), &
+                    'put_4d_with_blocks put '//trim(var_name))
+    enddo
+
+end subroutine put_4d_with_blocks
+
 
       end module ice_history_write
-
-!=======================================================================

--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -47,6 +47,7 @@
          filename, filename0
 
       integer (kind=int_kind) :: status
+      integer (kind=int_kind) :: year
 
       if (present(ice_ic)) then 
          filename = trim(ice_ic)

--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -13,7 +13,7 @@
       use netcdf
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
-          runid, runtype, use_restart_time, restart_format, lcdf64, lenstr
+          runid, runtype, use_restart_time, restart_format, lenstr
 
       implicit none
       private
@@ -35,10 +35,6 @@
 
       use ice_calendar, only: sec, month, mday, nyr, istep0, istep1, &
                               time, time_forc, year_init, npt
-#ifdef ACCESS
-      use cpl_parameters, only: iniyear, inimon, iniday
-      use ice_calendar, only: check_start_date
-#endif
       use ice_communicate, only: my_task, master_task
       use ice_domain, only: nblocks
       use ice_fileunits, only: nu_diag, nu_rst_pointer
@@ -51,7 +47,6 @@
          filename, filename0
 
       integer (kind=int_kind) :: status
-      integer (kind=int_kind) :: year
 
       if (present(ice_ic)) then 
          filename = trim(ice_ic)
@@ -75,16 +70,36 @@
       
          if (use_restart_time) then
          status = nf90_get_att(ncid, nf90_global, 'istep1', istep0)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(istep1)', status)
+
          status = nf90_get_att(ncid, nf90_global, 'time', time)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(time)', status)
+
          status = nf90_get_att(ncid, nf90_global, 'time_forc', time_forc)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(time_forc)', status)
+
          status = nf90_get_att(ncid, nf90_global, 'nyr', nyr)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(nyr)', status)
+
          status = nf90_get_att(ncid, nf90_global, 'year', year)
-         if (status /= nf90_noerr) call abort_ice( &
-           'ice: Error reading year attribute from ncfile '//trim(filename))
+         call assert(status == NF90_NOERR, &
+                    ' reading year attribute from ncfile '//trim(filename))
          if (status == nf90_noerr) then
             status = nf90_get_att(ncid, nf90_global, 'month', month)
+            call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(month)', status)
+
             status = nf90_get_att(ncid, nf90_global, 'mday', mday)
+            call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(mday)', status)
+
             status = nf90_get_att(ncid, nf90_global, 'sec', sec)
+            call assert(status == NF90_NOERR, &
+                     'in init_restart_read, on nf90_get_att(sec)', status)
          endif
 
          if ( sec .ne. 0 ) then
@@ -164,7 +179,6 @@
         dimid_ni,   & ! netCDF identifiers
         dimid_nj,   & !
         dimid_ncat, & !
-        iflag,      & ! netCDF creation flag
         status        ! status variable from netCDF routine
 
       character (len=3) :: nchar
@@ -189,19 +203,42 @@
          write(nu_rst_pointer,'(a)') filename
          close(nu_rst_pointer)
 
-         iflag = NF90_NETCDF4
-         status = nf90_create(trim(filename), iflag, ncid)
-         if (status /= nf90_noerr) call abort_ice( &
-            'ice: Error creating restart ncfile '//trim(filename))
+         status = nf90_create(trim(filename), NF90_NETCDF4, ncid)
+         call assert(status == NF90_NOERR, &
+            'in init_restart_write on nf90_create '//trim(filename), status)
 
          status = nf90_put_att(ncid,nf90_global,'istep1',istep1)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(istep1)', status)
+
          status = nf90_put_att(ncid,nf90_global,'time',time)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(time)', status)
+
          status = nf90_put_att(ncid,nf90_global,'time_forc',time_forc)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(time_forc)', status)
+
          status = nf90_put_att(ncid,nf90_global,'nyr',nyr) ! year count since year_init
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(nyr)', status)
+
          status = nf90_put_att(ncid,nf90_global,'year',iyear) ! calendar year
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(year)', status)
+            status = nf90_put_att(ncid,nf90_global,'nyr',nyr)
+
          status = nf90_put_att(ncid,nf90_global,'month',month)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(month)', status)
+
          status = nf90_put_att(ncid,nf90_global,'mday',mday)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(mday)', status)
+
          status = nf90_put_att(ncid,nf90_global,'sec',sec)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_put_att(sec)', status)
 
          nx = nx_global
          ny = ny_global
@@ -210,9 +247,15 @@
             ny = ny_global + 2*nghost
          endif
          status = nf90_def_dim(ncid,'ni',nx,dimid_ni)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_def_dim(ni)', status)
          status = nf90_def_dim(ncid,'nj',ny,dimid_nj)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_def_dim(nj)', status)
 
          status = nf90_def_dim(ncid,'ncat',ncat,dimid_ncat)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_def_dim(ncat)', status)
 
       !-----------------------------------------------------------------
       ! 2D restart fields
@@ -392,8 +435,11 @@
 
          deallocate(dims)
          status = nf90_enddef(ncid)
+         call assert(status == NF90_NOERR, &
+                     'in init_restart_write on nf90_enddef', status)
 
          write(nu_diag,*) 'Writing ',filename(1:lenstr(filename))
+
       endif ! master_task
 
       end subroutine init_restart_write
@@ -494,6 +540,7 @@
       use ice_domain_size, only: max_blocks, ncat
       use ice_fileunits, only: nu_diag
       use ice_read_write, only: ice_write, ice_write_nc
+      use ice_communicate, only: my_task, master_task
 
       integer (kind=int_kind), intent(in) :: &
            nu            , & ! unit number
@@ -524,6 +571,10 @@
            work2              ! input array (real, 8-byte)
 
          status = nf90_inq_varid(ncid,trim(vname),varid)
+         if (my_task == master_task) then
+             call assert(status == NF90_NOERR, &
+                         'in write_restart_field on '//trim(vname), status)
+         endif
          if (ndim3 == ncat) then 
             if (restart_ext) then
                call ice_write_nc(ncid, 1, varid, work, diag, restart_ext)
@@ -556,10 +607,11 @@
 
       integer (kind=int_kind) :: status
 
-      status = nf90_close(ncid)
-
-      if (my_task == master_task) &
+      if (my_task == master_task) then
+         status = nf90_close(ncid)
+         call assert(status == NF90_NOERR, 'in final_restart', status)
          write(nu_diag,*) 'Restart read/written ',istep1,time,time_forc
+      endif
 
       end subroutine final_restart
 
@@ -580,10 +632,30 @@
         status        ! status variable from netCDF routine
 
       status = nf90_def_var(ncid,trim(vname),nf90_double,dims,varid)
+      call assert(status == NF90_NOERR, &
+                  'in define_rest_field, on '//trim(vname), status)
+      status = nf90_def_var_deflate(ncid, varid, 1, 1, 1)
+      call assert(status == NF90_NOERR, &
+                  'deflate in define_rest_field, on '//trim(vname), status)
         
       end subroutine define_rest_field
 
 !=======================================================================
+
+      subroutine assert(logical_arg, str_msg, error_code)
+
+      logical, intent(in) :: logical_arg
+      character(len=*), intent(in) :: str_msg
+      integer, intent(in) :: error_code
+      character(len=3) :: err_code_str
+
+      write(err_code_str, '(I3)') error_code
+
+      if (.not. logical_arg) then
+        call abort_ice('ice: Error '//err_code_str//' '//str_msg)
+      endif
+
+      end subroutine assert
 
       end module ice_restart
 

--- a/io_netcdf/ice_restart.F90
+++ b/io_netcdf/ice_restart.F90
@@ -35,6 +35,10 @@
 
       use ice_calendar, only: sec, month, mday, nyr, istep0, istep1, &
                               time, time_forc, year_init, npt
+#ifdef ACCESS
+      use cpl_parameters, only: iniyear, inimon, iniday
+      use ice_calendar, only: check_start_date
+#endif
       use ice_communicate, only: my_task, master_task
       use ice_domain, only: nblocks
       use ice_fileunits, only: nu_diag, nu_rst_pointer
@@ -68,7 +72,7 @@
          status = nf90_open(trim(filename), nf90_nowrite, ncid)
          if (status /= nf90_noerr) call abort_ice( &
             'ice: Error reading restart ncfile '//trim(filename))
-      
+
          if (use_restart_time) then
          status = nf90_get_att(ncid, nf90_global, 'istep1', istep0)
          call assert(status == NF90_NOERR, &
@@ -88,7 +92,7 @@
 
          status = nf90_get_att(ncid, nf90_global, 'year', year)
          call assert(status == NF90_NOERR, &
-                    ' reading year attribute from ncfile '//trim(filename))
+                    ' reading year attribute from ncfile '//trim(filename), status)
          if (status == nf90_noerr) then
             status = nf90_get_att(ncid, nf90_global, 'month', month)
             call assert(status == NF90_NOERR, &
@@ -130,7 +134,7 @@
       ! Check starting date and time are consistent
       call check_start_date
 #endif
-      
+
       istep1 = istep0
 
       ! if runid is bering then need to correct npt for istep0

--- a/source/ice_domain.F90
+++ b/source/ice_domain.F90
@@ -48,7 +48,8 @@
    logical (kind=log_kind), public :: &
       maskhalo_dyn   , & ! if true, use masked halo updates for dynamics
       maskhalo_remap , & ! if true, use masked halo updates for transport
-      maskhalo_bound     ! if true, use masked halo updates for bound_state
+      maskhalo_bound , & ! if true, use masked halo updates for bound_state
+      equal_num_blocks_per_cpu ! if true, all CPUs have the same number of blocks
 
 !-----------------------------------------------------------------------
 !
@@ -110,7 +111,8 @@
                          ns_boundary_type,  &
                          maskhalo_dyn,      &
                          maskhalo_remap,    &
-                         maskhalo_bound
+                         maskhalo_bound,    &
+                         equal_num_blocks_per_cpu
 
 !----------------------------------------------------------------------
 !
@@ -127,6 +129,7 @@
    maskhalo_dyn      = .false.     ! if true, use masked halos for dynamics
    maskhalo_remap    = .false.     ! if true, use masked halos for transport
    maskhalo_bound    = .false.     ! if true, use masked halos for bound_state
+   equal_num_blocks_per_cpu = .false. ! if true, all CPUs have the same number of blocks
 
    call get_fileunit(nu_nml)
    if (my_task == master_task) then
@@ -157,6 +160,7 @@
    call broadcast_scalar(maskhalo_dyn,      master_task)
    call broadcast_scalar(maskhalo_remap,    master_task)
    call broadcast_scalar(maskhalo_bound,    master_task)
+   call broadcast_scalar(equal_num_blocks_per_cpu, master_task)
 
 !----------------------------------------------------------------------
 !
@@ -428,6 +432,32 @@
      work_per_block = 0
    end where
    deallocate(nocn)
+
+  if (equal_num_blocks_per_cpu) then
+      ! Make sure that each PE has
+      ! the same number of blocks. This is needed when using parallel NetCDF
+      ! because all parallel writes are synchronous.
+
+      ! First calculate the number of padding blocks needed.
+      num_work_blocks = count(work_per_block /= 0)
+      num_padding_blocks = ceiling(real(num_work_blocks) / real(nprocs))*nprocs - num_work_blocks
+
+      ! Add padding blocks wherever necessary
+      p = 0
+      do n=1, nblocks_tot
+        if (p >= num_padding_blocks) then
+            exit
+        elseif (work_per_block(n) == 0) then
+            work_per_block(n) = 1
+            p = p + 1
+        endif
+      enddo
+
+      if (p /= num_padding_blocks) then
+        call abort_ice("ice: can't assign work to pad blocks")
+      endif
+  endif
+
 
 !----------------------------------------------------------------------
 !

--- a/source/ice_domain.F90
+++ b/source/ice_domain.F90
@@ -271,7 +271,7 @@
       max_work_unit=10    ! quantize the work into values from 1,max
 
    integer (int_kind) :: &
-      i,j,n              ,&! dummy loop indices
+      i,j,n,p            ,&! dummy loop indices
       ig,jg              ,&! global indices
       work_unit          ,&! size of quantized work unit
       tblocks_tmp        ,&! total number of blocks
@@ -284,6 +284,10 @@
 
    type (block) :: &
       this_block           ! block information for current block
+
+    ! The number of extra blocks that need to be added so that each PE
+    ! has an equal number.
+    integer (int_kind) :: num_padding_blocks, num_work_blocks
 
 !----------------------------------------------------------------------
 !

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -44,6 +44,19 @@
          history_dir   , & ! directory name for history file
          incond_dir        ! directory for snapshot initial conditions
 
+      integer, public :: &
+         history_deflate_level ! Deflation/compression level to use for
+                               ! netCDF4 output
+
+      logical, public :: &
+         history_parallel_io   ! Use parallel write for netCDF4 output
+
+      integer, public :: &
+         history_chunksize_x   ! NetCDF chunksize in x/lon dimension
+
+      integer, public :: &
+         history_chunksize_y   ! NetCDF chunksize in y/lat dimension
+
       character (len=char_len_long), public :: &
          pointer_file      ! input pointer file for restarts
 

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -129,7 +129,7 @@
         dt,             npt,            ndtd,                           &
         runtype,        runid,          bfbflag,                        &
         ice_ic,         restart,        restart_dir,     restart_file,  &
-        restart_ext,    use_restart_time, restart_format, lcdf64,       &
+        restart_ext,    use_restart_time, restart_format,               &
         pointer_file,   dumpfreq,       dumpfreq_n,      dump_last,     &
         diagfreq,       diag_type,      diag_file,                      &
         print_global,   print_points,   latpnt,          lonpnt,        &

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -54,8 +54,10 @@
                               write_ic, dump_last
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
-          runid, runtype, use_restart_time, restart_format, lcdf64
+          runid, runtype, use_restart_time, restart_format
       use ice_history_shared, only: hist_avg, history_dir, history_file, &
+                             history_deflate_level, history_parallel_io, &
+                             history_chunksize_x, history_chunksize_y,   &
                              incond_dir, incond_file
       use ice_exit, only: abort_ice
       use ice_itd, only: kitd, kcatbound
@@ -132,7 +134,8 @@
         diagfreq,       diag_type,      diag_file,                      &
         print_global,   print_points,   latpnt,          lonpnt,        &
         dbug,           histfreq,       histfreq_n,      hist_avg,      &
-        history_dir,    history_file,                                   &
+        history_dir,    history_file,   history_deflate_level,          &
+        history_parallel_io, history_chunksize_x, history_chunksize_y,  &
         write_ic,       incond_dir,     incond_file
 
       namelist /grid_nml/ &
@@ -222,6 +225,14 @@
       hist_avg = .true.      ! if true, write time-averages (not snapshots)
       history_dir  = './'    ! write to executable dir for default
       history_file = 'iceh'  ! history file name prefix
+      history_deflate_level = -1 ! Deflate/compression level to use when
+                                 ! writing netCDF4 history files, -1
+                                 ! means no deflation
+      history_parallel_io = .false. ! Use NetCDF parallel IO to write out history files
+      history_chunksize_x = -1 ! NetCDF chunksize in x/lon dimension. -1
+                               ! means use default selected by NetCDF library
+      history_chunksize_y = -1 ! NetCDF chunksize in y/lat dimension
+                               ! means use default selected by NetCDF library
       write_ic = .false.     ! write out initial condition
       incond_dir = history_dir ! write to history dir for default
       incond_file = 'iceh_ic'! file prefix
@@ -235,7 +246,6 @@
       use_restart_time = .true.     ! if true, use time info written in file
       pointer_file = 'ice.restart_file'
       restart_format = 'nc'  ! file format ('bin'=binary or 'nc'=netcdf or 'pio')
-      lcdf64       = .false. ! 64 bit offset for netCDF
       ice_ic       = 'default'      ! latitude and sst-dependent
       grid_format  = 'bin'          ! file format ('bin'=binary or 'nc'=netcdf)
       grid_type    = 'rectangular'  ! define rectangular grid internally
@@ -740,6 +750,10 @@
       call broadcast_scalar(hist_avg,           master_task)
       call broadcast_scalar(history_dir,        master_task)
       call broadcast_scalar(history_file,       master_task)
+      call broadcast_scalar(history_deflate_level, master_task)
+      call broadcast_scalar(history_parallel_io, master_task)
+      call broadcast_scalar(history_chunksize_x, master_task)
+      call broadcast_scalar(history_chunksize_y, master_task)
       call broadcast_scalar(write_ic,           master_task)
       call broadcast_scalar(incond_dir,         master_task)
       call broadcast_scalar(incond_file,        master_task)
@@ -752,7 +766,6 @@
       call broadcast_scalar(restart_ext,        master_task)
       call broadcast_scalar(use_restart_time,   master_task)
       call broadcast_scalar(restart_format,     master_task)
-      call broadcast_scalar(lcdf64,             master_task)
       call broadcast_scalar(pointer_file,       master_task)
       call broadcast_scalar(ice_ic,             master_task)
       call broadcast_scalar(grid_format,        master_task)
@@ -910,6 +923,8 @@
                                trim(history_dir)
          write(nu_diag,*)    ' history_file              = ', &
                                trim(history_file)
+         write(nu_diag,*)    ' history_deflate_level     = ', &
+                               history_deflate_level
          if (write_ic) then
             write (nu_diag,*) 'Initial condition will be written in ', &
                                trim(incond_dir)
@@ -924,8 +939,6 @@
          write(nu_diag,*)    ' restart_ext               = ', restart_ext
          write(nu_diag,*)    ' restart_format            = ', &
                                trim(restart_format)
-         write(nu_diag,*)    ' lcdf64                    = ', &
-                               lcdf64
          write(nu_diag,*)    ' restart_file              = ', &
                                trim(restart_file)
          write(nu_diag,*)    ' pointer_file              = ', &

--- a/source/ice_restart_driver.F90
+++ b/source/ice_restart_driver.F90
@@ -21,7 +21,7 @@
       use ice_kinds_mod
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
-          runid, runtype, use_restart_time, restart_format, lcdf64, lenstr
+          runid, runtype, use_restart_time, restart_format, lenstr
       use ice_restart
 #ifdef AusCOM
       use cpl_parameters, only: runtime0

--- a/source/ice_restart_shared.F90
+++ b/source/ice_restart_shared.F90
@@ -27,8 +27,6 @@
       character (len=char_len), public :: &
          restart_format    ! format of restart files 'nc'
 
-      logical (kind=log_kind), public :: lcdf64
-
 !=======================================================================
 
       contains


### PR DESCRIPTION
I've ported the cice5 code for netcdf output from the master branch, to include Nic's work on chunking/compression etc.

The goal here is to make it incorporate the relevant source in a way that allows the access-esm1.6 branch to be easily merged into the master branch in the future without impacting access-om2.

Results are BFB - see https://github.com/ACCESS-NRI/access-esm1.6-configs/pull/158

Using `history_deflate_level = 1` in `, results in ~760kB per day vs ~6.3MB per day before. 

One year without this change has Walltime Used: ~01:15:14 , and after the change ~01:11:26 (I expected the new method to be slower based on access-om3 results, so this may not be indicative).

Contributes to #56 