### PR TITLE
Support multiple history timesteps per file

### DIFF
--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -87,61 +87,30 @@ end subroutine check
 
       subroutine ice_write_hist (ns)
 
-            use ice_calendar, only: time, sec, idate, idate0, &
+      use ice_calendar, only: time, sec, idate, idate0, &
 #ifdef ACCESS
         month, daymo, &
 #endif
         dayyr, days_per_year, use_leap_years
       use ice_fileunits, only: nu_diag
-      use ice_restart_shared, only: runid
 
-      integer (kind=int_kind), intent(in) :: ns
+      integer (kind=int_kind), intent(in) :: ns !history stream number
 
       ! local variables
 
-      real (kind=dbl_kind),  dimension(:,:),   allocatable :: work_g1
-      real (kind=real_kind), dimension(:,:),   allocatable :: work_gr
-      real (kind=real_kind), dimension(:,:,:), allocatable :: work_gr3
-      real (kind=dbl_kind),  dimension(nx_block,ny_block,max_blocks) :: &
-         work1
-
-      integer (kind=int_kind) :: i,k,ic,n,nn, &
-         ncid,status,imtid,jmtid,kmtidi,kmtids,kmtidb, cmtid,timid,varid, &
-         nvertexid,ivertex
-      integer (kind=int_kind), dimension(3) :: dimid
-      integer (kind=int_kind), dimension(4) :: dimidz
-      integer (kind=int_kind), dimension(5) :: dimidcz
-      integer (kind=int_kind), dimension(3) :: dimid_nverts
-      integer (kind=int_kind), dimension(4) :: dimidex
-      real (kind=real_kind) :: ltime
-      character (char_len) :: title
-      character (char_len_long) :: ncfile(max_nstrm)
-
-      integer (kind=int_kind) :: shuffle, deflate, deflate_level
-
-      integer (kind=int_kind) :: ind,boundid
-
-      character (char_len) :: start_time,current_date,current_time
-      character (len=8) :: cdate
+      real (kind=real_kind) :: ltime                 !history timestamp in seconds
+      character (char_len_long) :: ncfile(max_nstrm) !filenames
+      logical :: file_exists
+      integer (kind=int_kind) :: & 
+        ncid,   &    ! netcdf id
+        varid,  &
+        i_time, &    ! time index
+        timid       ! time var id
 
       TYPE(req_attributes), dimension(nvar) :: var
       TYPE(coord_attributes), dimension(ncoord) :: coord_var
       TYPE(coord_attributes), dimension(nvar_verts) :: var_nverts
       TYPE(coord_attributes), dimension(nvarz) :: var_nz
-      CHARACTER (char_len), dimension(ncoord) :: coord_bounds
-
-      ! We leave shuffle at 0, this is only useful for integer data.
-      shuffle = 0
-
-      ! If history_deflate_level < 0 then don't do deflation,
-      ! otherwise it sets the deflate level
-      if (history_deflate_level < 0) then
-         deflate = 0
-         deflate_level = 0
-      else
-         deflate = 1
-         deflate_level = history_deflate_level
-      endif
 
       if (my_task == master_task .or. history_parallel_io) then
 #if defined(ACCESS)
@@ -170,97 +139,244 @@ end subroutine check
           ncfile(ns) = trim(history_dir)//ncfile(ns)
         endif
 
-        ! create file
-        if (history_parallel_io) then
-            call check(nf90_create(ncfile(ns), ior(NF90_NETCDF4, NF90_MPIIO), ncid, &
-                                   comm=MPI_COMM_ICE, info=MPI_INFO_NULL), &
-                        'create history ncfile '//ncfile(ns))
-            if (.not. equal_num_blocks_per_cpu) then
-                call abort_ice('ice: error history_parallel_io needs equal_num_blocks_per_cpu')
-            endif
+        inquire(file=trim(ncfile(ns)),exist=file_exists)
+        if (.not. file_exists) then 
+          write(nu_diag,*) 'creating'//trim(ncfile(ns))
+          call ice_hist_create(ns, ncfile(ns), ncid, var, coord_var, var_nverts, var_nz)
+          write(nu_diag,*) 'created'//trim(ncfile(ns))
         else
-            call check(nf90_create(ncfile(ns), ior(NF90_CLASSIC_MODEL, NF90_HDF5), ncid), &
-                        'create history ncfile '//ncfile(ns))
+          if (history_parallel_io) then
+            call check(nf90_open(trim(ncfile(ns)), NF90_WRITE, ncid, &
+                                   comm=MPI_COMM_ICE, info=MPI_INFO_NULL), &
+                        'parallel open existing history file '//ncfile(ns))
+          else
+            call check(nf90_open(trim(ncfile(ns)), NF90_WRITE, ncid), &
+                        "opening existing history file "//ncfile(ns))
+          endif
         endif
 
       !-----------------------------------------------------------------
-      ! define dimensions
+      ! write time variable
+      !-----------------------------------------------------------------
+        call check(nf90_inq_dimid(ncid, 'time', timid), &
+                    'inq dimid time')
+        call check(nf90_inquire_dimension(ncid, timid, len=i_time), &
+                    'inquire dim time')
+        call check(nf90_inq_varid(ncid,'time',varid), &
+                   'inq varid time')
+        if (history_parallel_io) then
+          ! unlimited dimensions need to have collective access set
+          call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+                   'parallel access time')
+        endif
+        i_time = i_time + 1 ! index of the current history time
+        call check(nf90_put_var(ncid,varid,ltime,start=(/i_time/)), &
+                   'put var time')
+
+      !-----------------------------------------------------------------
+      ! write time_bounds info
       !-----------------------------------------------------------------
 
         if (hist_avg) then
-            call check(nf90_def_dim(ncid,'d2',2,boundid), 'def dim d2')
+            call check(nf90_inq_varid(ncid,'time_bounds',varid), &
+                       'inq varid time_bounds')
+            call check(nf90_put_var(ncid,varid,time_beg(ns),start=(/1,i_time/)), &
+                       'put var time_bounds beginning')
+            call check(nf90_put_var(ncid,varid,time_end(ns),start=(/2,i_time/)), &
+                       'put var time_bounds end')
         endif
+      endif                     ! master_task or history_parallel_io
 
-        call check(nf90_def_dim(ncid, 'ni', nx_global, imtid), &
-                    'def dim ni')
-        call check(nf90_def_dim(ncid, 'nj', ny_global, jmtid), &
-                    'def dim nj')
-        call check(nf90_def_dim(ncid, 'nc', ncat_hist, cmtid), &
-                    'def dim nc')
-        call check(nf90_def_dim(ncid, 'nkice', nzilyr, kmtidi), &
-                    'def dim nkice')
-        call check(nf90_def_dim(ncid, 'nksnow', nzslyr, kmtids), &
-                    'def dim nksnow')
-        call check(nf90_def_dim(ncid, 'nkbio', nzblyr, kmtidb), &
-                    'def dim nkbio')
-        call check(nf90_def_dim(ncid, 'time', NF90_UNLIMITED, timid), &
-                    'def dim time')
-        call check(nf90_def_dim(ncid, 'nvertices', nverts, nvertexid), &
-                    'def dim nverts')
+    call broadcast_scalar(i_time, master_task) !we need this on every processor for parallel writes
+    if (i_time == 1) then
+      ! these are time-invariant, only write once
+      !-----------------------------------------------------------------
+      ! write coordinate variables
+      !-----------------------------------------------------------------
+      if (history_parallel_io) then
+          call write_coordinate_variables_parallel(ncid, coord_var, var_nz)
+      else
+          call write_coordinate_variables(ncid, coord_var, var_nz)
+      endif
 
       !-----------------------------------------------------------------
-      ! define coordinate variables
+      ! write grid masks, area and rotation angle
       !-----------------------------------------------------------------
+      if (history_parallel_io) then
+          call write_grid_variables_parallel(ncid, var, var_nverts)
+      else
+          call write_grid_variables(ncid, var, var_nverts)
+      endif
 
-        call check(nf90_def_var(ncid,'time',nf90_float,timid,varid), &
-                      'def var time')
-        call check(nf90_put_att(ncid,varid,'long_name','model time'), &
-                    'put_att long_name')
+    endif
+    !-----------------------------------------------------------------
+    ! write 2d variable data
+    !-----------------------------------------------------------------
 
+    if (history_parallel_io) then
+        call write_2d_variables_parallel(ns, ncid, i_time)
+    else
+        call write_2d_variables(ns, ncid, i_time)
+    endif
+
+    if (history_parallel_io) then
+        call write_3d_and_4d_variables_parallel(ns, ncid, i_time)
+    else
+       call write_3d_and_4d_variables(ns, ncid, i_time)
+    endif
+
+    !-----------------------------------------------------------------
+    ! close output dataset
+    !-----------------------------------------------------------------
+
+    if (my_task == master_task .or. history_parallel_io) then
+        call check(nf90_close(ncid), 'closing netCDF history file')
+        write(nu_diag,*) 'Finished writing ',trim(ncfile(ns)),' at time'
+    endif
+
+end subroutine ice_write_hist
+
+subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
+
+      use ice_calendar, only: time, sec, idate, idate0, &
+#ifdef ACCESS
+        month, daymo, &
+#endif
+        dayyr, days_per_year, use_leap_years
+      use ice_fileunits, only: nu_diag
+      use ice_restart_shared, only: runid
+
+      integer (kind=int_kind), intent(in) :: ns
+      character (char_len_long), intent(in) :: ncfile
+      integer (kind=int_kind), intent(out) :: ncid
+      TYPE(req_attributes), dimension(nvar), intent(inout) :: var
+      TYPE(coord_attributes), dimension(ncoord), intent(inout) :: coord_var
+      TYPE(coord_attributes), dimension(nvar_verts), intent(inout) :: var_nverts
+      TYPE(coord_attributes), dimension(nvarz), intent(inout) :: var_nz
+
+      ! local variables
+
+      integer (kind=int_kind) :: i,k,ic,n,nn, &
+        status,imtid,jmtid,kmtidi,kmtids,kmtidb, cmtid,timid,varid, &
+        nvertexid,ivertex
+      integer (kind=int_kind), dimension(3) :: dimid, dimid_nverts
+      integer (kind=int_kind), dimension(4) :: dimidz, dimidex
+      integer (kind=int_kind), dimension(5) :: dimidcz
+
+      integer (kind=int_kind) :: shuffle, deflate, deflate_level ! comrpession settings
+
+      integer (kind=int_kind) :: ind,boundid
+
+      character (char_len) :: title, start_time,current_date,current_time
+      character (len=8) :: cdate
+
+
+      CHARACTER (char_len), dimension(ncoord) :: coord_bounds
+
+      ! We leave shuffle at 0, this is only useful for integer data.
+      shuffle = 0
+
+      ! If history_deflate_level < 0 then don't do deflation,
+      ! otherwise it sets the deflate level
+      if (history_deflate_level < 0) then
+        deflate = 0
+        deflate_level = 0
+      else
+        deflate = 1
+        deflate_level = history_deflate_level
+      endif
+
+      ! create file
+      if (history_parallel_io) then
+          call check(nf90_create(ncfile, ior(NF90_NETCDF4, NF90_MPIIO), ncid, &
+                                  comm=MPI_COMM_ICE, info=MPI_INFO_NULL), &
+                      'create history ncfile '//ncfile)
+          if (.not. equal_num_blocks_per_cpu) then
+              call abort_ice('ice: error history_parallel_io needs equal_num_blocks_per_cpu')
+          endif
+      else
+          call check(nf90_create(ncfile, ior(NF90_CLASSIC_MODEL, NF90_HDF5), ncid), &
+                      'create history ncfile '//ncfile)
+      endif
+
+    !-----------------------------------------------------------------
+    ! define dimensions
+    !-----------------------------------------------------------------
+
+      if (hist_avg) then
+          call check(nf90_def_dim(ncid,'d2',2,boundid), 'def dim d2')
+      endif
+
+      call check(nf90_def_dim(ncid, 'ni', nx_global, imtid), &
+                  'def dim ni')
+      call check(nf90_def_dim(ncid, 'nj', ny_global, jmtid), &
+                  'def dim nj')
+      call check(nf90_def_dim(ncid, 'nc', ncat_hist, cmtid), &
+                  'def dim nc')
+      call check(nf90_def_dim(ncid, 'nkice', nzilyr, kmtidi), &
+                  'def dim nkice')
+      call check(nf90_def_dim(ncid, 'nksnow', nzslyr, kmtids), &
+                  'def dim nksnow')
+      call check(nf90_def_dim(ncid, 'nkbio', nzblyr, kmtidb), &
+                  'def dim nkbio')
+      call check(nf90_def_dim(ncid, 'time', NF90_UNLIMITED, timid), &
+                  'def dim time')
+      call check(nf90_def_dim(ncid, 'nvertices', nverts, nvertexid), &
+                  'def dim nverts')
+
+    !-----------------------------------------------------------------
+    ! define coordinate variables
+    !-----------------------------------------------------------------
+
+      call check(nf90_def_var(ncid,'time',nf90_float,timid,varid), &
+                    'def var time')
+      call check(nf90_put_att(ncid,varid,'long_name','model time'), &
+                  'put_att long_name')
+
+      write(cdate,'(i8.8)') idate0
+      write(title,'(a,a,a,a,a,a,a,a)') 'days since ', &
+            cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
+      call check(nf90_put_att(ncid,varid,'units',title), &
+                  'put_att time units')
+
+      if (days_per_year == 360) then
+          call check(nf90_put_att(ncid,varid,'calendar','360_day'), &
+                        'att time calendar')
+      elseif (days_per_year == 365 .and. .not.use_leap_years ) then
+          call check(nf90_put_att(ncid,varid,'calendar','NoLeap'), &
+                        'att time calendar')
+      elseif (use_leap_years) then
+          call check(nf90_put_att(ncid,varid,'calendar','proleptic_gregorian'), &
+                        'att time calendar')
+      else
+          call abort_ice( 'ice Error: invalid calendar settings')
+      endif
+
+      if (hist_avg) then
+          call check(nf90_put_att(ncid,varid,'bounds','time_bounds'), &
+                      'att time bounds')
+      endif
+
+    !-----------------------------------------------------------------
+    ! Define attributes for time bounds if hist_avg is true
+    !-----------------------------------------------------------------
+
+      if (hist_avg) then
+        dimid(1) = boundid
+        dimid(2) = timid
+        call check(nf90_def_var(ncid, 'time_bounds', &
+                              nf90_float,dimid(1:2),varid), &
+                    'def var time_bounds')
+
+        call check(nf90_put_att(ncid,varid,'long_name', &
+                            'boundaries for time-averaging interval'), &
+                    'att time_bounds long_name')
         write(cdate,'(i8.8)') idate0
         write(title,'(a,a,a,a,a,a,a,a)') 'days since ', &
               cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
         call check(nf90_put_att(ncid,varid,'units',title), &
-                    'put_att time units')
-
-        if (days_per_year == 360) then
-            call check(nf90_put_att(ncid,varid,'calendar','360_day'), &
-                         'att time calendar')
-        elseif (days_per_year == 365 .and. .not.use_leap_years ) then
-            call check(nf90_put_att(ncid,varid,'calendar','NoLeap'), &
-                         'att time calendar')
-        elseif (use_leap_years) then
-            call check(nf90_put_att(ncid,varid,'calendar','proleptic_gregorian'), &
-                         'att time calendar')
-        else
-           call abort_ice( 'ice Error: invalid calendar settings')
-        endif
-
-        if (hist_avg) then
-            call check(nf90_put_att(ncid,varid,'bounds','time_bounds'), &
-                        'att time bounds')
-        endif
-
-      !-----------------------------------------------------------------
-      ! Define attributes for time bounds if hist_avg is true
-      !-----------------------------------------------------------------
-
-        if (hist_avg) then
-          dimid(1) = boundid
-          dimid(2) = timid
-          call check(nf90_def_var(ncid, 'time_bounds', &
-                                nf90_float,dimid(1:2),varid), &
-                      'def var time_bounds')
-
-          call check(nf90_put_att(ncid,varid,'long_name', &
-                              'boundaries for time-averaging interval'), &
-                      'att time_bounds long_name')
-          write(cdate,'(i8.8)') idate0
-          write(title,'(a,a,a,a,a,a,a,a)') 'days since ', &
-                cdate(1:4),'-',cdate(5:6),'-',cdate(7:8),' 00:00:00'
-          call check(nf90_put_att(ncid,varid,'units',title), &
-                                'att time_bounds units')
-        endif
+                              'att time_bounds units')
+      endif
 
       !-----------------------------------------------------------------
       ! define information for required time-invariant variables
@@ -969,13 +1085,9 @@ end subroutine check
         call check(nf90_put_att(ncid,nf90_global,'comment',title), &
                    'global attribute comment')
 
-        write(title,'(a,i8.8)') 'File written on model date ',idate
+        write(title,'(a,i8.8)') 'File started on model date ',idate
         call check(nf90_put_att(ncid,nf90_global,'comment2',title), &
                    'global attribute comment2')
-
-        write(title,'(a,i6)') 'seconds elapsed into model date: ',sec
-        call check(nf90_put_att(ncid,nf90_global,'comment3',title), &
-                   'global attribute comment3')
 
         title = 'CF-1.0'
         call check(nf90_put_att(ncid,nf90_global,'conventions',title), &
@@ -994,88 +1106,14 @@ end subroutine check
         call check(nf90_put_att(ncid,nf90_global,'io_flavor','io_netcdf'), &
                    'global attribute io_flavor')
 
-      !-----------------------------------------------------------------
-      ! end define mode
-      !-----------------------------------------------------------------
+        !-----------------------------------------------------------------
+        ! end define mode
+        !-----------------------------------------------------------------
 
         call check(nf90_enddef(ncid), 'enddef')
 
-      !-----------------------------------------------------------------
-      ! write time variable
-      !-----------------------------------------------------------------
+end subroutine ice_hist_create
 
-        call check(nf90_inq_varid(ncid,'time',varid), &
-                   'inq varid time')
-        if (history_parallel_io) then
-          ! unlimited dimensions need to have collective access set
-          call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-                   'parallel access time')
-        endif
-        call check(nf90_put_var(ncid,varid,ltime), &
-                   'put var time')
-
-      !-----------------------------------------------------------------
-      ! write time_bounds info
-      !-----------------------------------------------------------------
-
-        if (hist_avg) then
-            call check(nf90_inq_varid(ncid,'time_bounds',varid), &
-                       'inq varid time_bounds')
-            call check(nf90_put_var(ncid,varid,time_beg(ns),start=(/1/)), &
-                       'put var time_bounds beginning')
-            call check(nf90_put_var(ncid,varid,time_end(ns),start=(/2/)), &
-                       'put var time_bounds end')
-        endif
-    endif                     ! master_task or history_parallel_io
-
-    !-----------------------------------------------------------------
-    ! write coordinate variables
-    !-----------------------------------------------------------------
-
-    if (history_parallel_io) then
-        call write_coordinate_variables_parallel(ncid, coord_var, var_nz)
-    else
-        call write_coordinate_variables(ncid, coord_var, var_nz)
-    endif
-
-    !-----------------------------------------------------------------
-    ! write grid masks, area and rotation angle
-    !-----------------------------------------------------------------
-
-    if (history_parallel_io) then
-        call write_grid_variables_parallel(ncid, var, var_nverts)
-    else
-        call write_grid_variables(ncid, var, var_nverts)
-    endif
-
-
-    !-----------------------------------------------------------------
-    ! write 2d variable data
-    !-----------------------------------------------------------------
-
-    if (history_parallel_io) then
-        call write_2d_variables_parallel(ns, ncid)
-    else
-        call write_2d_variables(ns, ncid)
-    endif
-
-    if (history_parallel_io) then
-        call write_3d_and_4d_variables_parallel(ns, ncid)
-    else
-        call write_3d_and_4d_variables(ns, ncid)
-    endif
-
-    !-----------------------------------------------------------------
-    ! close output dataset
-    !-----------------------------------------------------------------
-
-    if (my_task == master_task .or. history_parallel_io) then
-        call check(nf90_close(ncid), 'closing netCDF history file')
-        write(nu_diag,*) ' '
-        write(nu_diag,*) 'Finished writing ',trim(ncfile(ns))
-    endif
-
-end subroutine ice_write_hist
 
 subroutine write_coordinate_variables(ncid, coord_var, var_nz)
 
@@ -1101,8 +1139,8 @@ subroutine write_coordinate_variables(ncid, coord_var, var_nz)
 
       work_g1(:,:) = c0
 
-        do i = 1,ncoord
-        coord_var_name = coord_var(i)%short_name
+      do i = 1,ncoord
+        if (my_task == master_task) coord_var_name = coord_var(i)%short_name
         call broadcast_scalar(coord_var_name, master_task)
         SELECT CASE (coord_var_name)
             CASE ('TLON')
@@ -1121,9 +1159,9 @@ subroutine write_coordinate_variables(ncid, coord_var, var_nz)
               work1 = ULAT*rad_to_deg
               call gather_global(work_g1,work1,master_task,distrb_info)
           END SELECT
-          
+
           if (my_task == master_task) then
-             work_gr = work_g1
+            work_gr = work_g1
             call check(nf90_inq_varid(ncid, coord_var_name, varid), &
                         'inq varid '//coord_var_name)
             call check(nf90_put_var(ncid,varid,work_gr), &
@@ -1134,12 +1172,13 @@ subroutine write_coordinate_variables(ncid, coord_var, var_nz)
         ! Extra dimensions (NCAT, VGRD*)
 
         do i = 1, nvarz
+          if (my_task == master_task) coord_var_name = var_nz(i)%short_name
           if (igrdz(i)) then
-          call broadcast_scalar(var_nz(i)%short_name,master_task)
+          call broadcast_scalar(coord_var_name,master_task)
           if (my_task == master_task) then
-            call check(nf90_inq_varid(ncid, var_nz(i)%short_name, varid), &
-                     'inq varid '//var_nz(i)%short_name)
-             SELECT CASE (var_nz(i)%short_name)
+            call check(nf90_inq_varid(ncid, coord_var_name, varid), &
+                     'inq varid '//coord_var_name)
+             SELECT CASE (coord_var_name)
                CASE ('NCAT') 
                  status = nf90_put_var(ncid,varid,hin_max(1:ncat_hist))
                CASE ('VGRDi') ! index - needed for Met Office analysis code
@@ -1150,7 +1189,7 @@ subroutine write_coordinate_variables(ncid, coord_var, var_nz)
                  status = nf90_put_var(ncid,varid,(/(k, k=1,nzblyr)/))
              END SELECT
              if (status /= nf90_noerr) call abort_ice( &
-                           'ice: Error writing'//var_nz(i)%short_name)
+                           'ice: Error writing'//coord_var_name)
           endif
           endif
         enddo
@@ -1216,10 +1255,9 @@ subroutine write_grid_variables(ncid, var, var_nverts)
 
       do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
         if (igrd(i)) then
-            var_name = var(i)%req%short_name
-
-            call broadcast_scalar(var_name,master_task)
-            SELECT CASE (var_name)
+          if (my_task == master_task) var_name = var(i)%req%short_name
+          call broadcast_scalar(var_name,master_task)
+          SELECT CASE (var_name)
           CASE ('tarea')
             call gather_global(work_g1, tarea, master_task, distrb_info)
           CASE ('uarea')
@@ -1261,9 +1299,9 @@ subroutine write_grid_variables(ncid, var, var_nverts)
       work1   (:,:,:) = c0
 
       do i = 1, nvar_verts
-            var_nverts_name = var_nverts(i)%short_name
-            call broadcast_scalar(var_nverts_name,master_task)
-            SELECT CASE (var_nverts_name)
+        if (my_task == master_task) var_nverts_name = var_nverts(i)%short_name
+        call broadcast_scalar(var_nverts_name,master_task)
+        SELECT CASE (var_nverts_name)
         CASE ('lont_bounds')
         do ivertex = 1, nverts 
            work1(:,:,:) = lont_bounds(ivertex,:,:,:)
@@ -1306,10 +1344,9 @@ subroutine write_grid_variables(ncid, var, var_nverts)
 end subroutine write_grid_variables
 
 
-subroutine write_2d_variables(ns, ncid)
+subroutine write_2d_variables(ns, ncid, i_time)
 
-    integer, intent(in) :: ns
-    integer, intent(in) :: ncid
+    integer, intent(in) :: ns, ncid, i_time
 
     real (kind=dbl_kind),  dimension(:,:), allocatable :: work_g1
     real (kind=real_kind), dimension(:,:), allocatable :: work_gr
@@ -1337,6 +1374,7 @@ subroutine write_2d_variables(ns, ncid)
                 call check(nf90_inq_varid(ncid,avail_hist_fields(n)%vname,varid), &
                            'inq varid '//avail_hist_fields(n)%vname)
                 call check(nf90_put_var(ncid,varid,work_gr(:,:), &
+                                        start=(/1,1,i_time/), &
                                         count=(/nx_global,ny_global/)), &
                             'put var '//avail_hist_fields(n)%vname)
           endif
@@ -1349,10 +1387,9 @@ subroutine write_2d_variables(ns, ncid)
 end subroutine write_2d_variables
 
 
-subroutine write_3d_and_4d_variables(ns, ncid)
+subroutine write_3d_and_4d_variables(ns, ncid, i_time)
 
-    integer, intent(in) :: ns
-    integer, intent(in) :: ncid
+    integer, intent(in) :: ns, ncid, i_time
 
     real (kind=dbl_kind),  dimension(:,:), allocatable :: work_g1
     real (kind=real_kind), dimension(:,:), allocatable :: work_gr
@@ -1385,7 +1422,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
 
              if (my_task == master_task) then
                     call check(nf90_put_var(ncid,varid,work_gr(:,:), &
-                                            start=(/        1,        1, k/), &
+                                            start=(/1,1,k,i_time/), &
                                             count=(/nx_global,ny_global, 1/)), &
                                'put var '//avail_hist_fields(n)%vname)
              endif
@@ -1410,7 +1447,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
 
              if (my_task == master_task) then
                     call check(nf90_put_var(ncid,varid,work_gr(:,:), &
-                                    start=(/        1,        1,k/), &
+                                            start=(/1,1,k,i_time/), &
                                             count=(/nx_global,ny_global,1/)), &
                                'put var '//avail_hist_fields(n)%vname)
            endif
@@ -1435,7 +1472,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
 
              if (my_task == master_task) then
                     call check(nf90_put_var(ncid,varid,work_gr(:,:),    &
-                                    start=(/        1,        1,k/), &
+                                            start=(/1,1,k,i_time/), &
                                             count=(/nx_global,ny_global,1/)), &
                                'put var '//avail_hist_fields(n)%vname)
            endif
@@ -1460,7 +1497,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
                         call check(nf90_put_var(ncid,varid,work_gr(:,:), &
-                                         start=(/        1,        1,k,ic/), &
+                                                start=(/1,1,k,ic,i_time/), &
                                                 count=(/nx_global,ny_global,1, 1/)), &
                                    'put var '//avail_hist_fields(n)%vname)
                 endif
@@ -1486,7 +1523,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
                         call check(nf90_put_var(ncid,varid,work_gr(:,:), &
-                                         start=(/        1,        1,k,ic/), &
+                                                start=(/1,1,k,ic,i_time/), &
                                                 count=(/nx_global,ny_global,1, 1/)), &
                                   'put var '//avail_hist_fields(n)%vname)
                 endif
@@ -1512,7 +1549,7 @@ subroutine write_3d_and_4d_variables(ns, ncid)
                 work_gr(:,:) = work_g1(:,:)
                 if (my_task == master_task) then
                         call check(nf90_put_var(ncid,varid,work_gr(:,:), &
-                                         start=(/        1,        1,k,ic/), &
+                                                start=(/1,1,k,ic,i_time/), &
                                                 count=(/nx_global,ny_global,1, 1/)), &
                                    'put var '//avail_hist_fields(n)%vname)
                 endif
@@ -1552,7 +1589,7 @@ subroutine write_coordinate_variables_parallel(ncid, coord_var, var_nz)
             work1 = ULAT*rad_to_deg
         END SELECT
 
-        call put_2d_with_blocks(ncid, coord_var(i)%short_name, work1)
+        call put_2d_with_blocks(ncid, 1, coord_var(i)%short_name, work1)
     enddo
 
     ! Extra dimensions (NCAT, VGRD*)
@@ -1598,11 +1635,11 @@ subroutine write_grid_variables_parallel(ncid, var, var_nverts)
     integer :: varid
 
     if (igrd(n_tmask)) then
-        call put_2d_with_blocks(ncid, 'tmask', hm)
+        call put_2d_with_blocks(ncid, 1, 'tmask', hm)
     endif
 
     if (igrd(n_blkmask)) then
-        call put_2d_with_blocks(ncid, 'blkmask', bm)
+        call put_2d_with_blocks(ncid, 1, 'blkmask', bm)
     endif
 
     do i = 3, nvar      ! note n_tmask=1, n_blkmask=2
@@ -1630,7 +1667,7 @@ subroutine write_grid_variables_parallel(ncid, var, var_nverts)
                 work1 = ANGLET
             END SELECT
 
-            call put_2d_with_blocks(ncid, var(i)%req%short_name, work1)
+            call put_2d_with_blocks(ncid, 1, var(i)%req%short_name, work1)
         endif
     enddo
 
@@ -1679,17 +1716,16 @@ subroutine write_grid_variables_parallel(ncid, var, var_nverts)
 end subroutine write_grid_variables_parallel
 
 
-subroutine write_2d_variables_parallel(ns, ncid)
+subroutine write_2d_variables_parallel(ns, ncid, i_time)
 
-    integer, intent(in) :: ns
-    integer, intent(in) :: ncid
+    integer, intent(in) :: ns, ncid, i_time
 
     integer :: varid
     integer :: n
 
     do n=1, num_avail_hist_fields_2D
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_2d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_2d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     a2D(:, :, n, :))
         endif
     enddo ! num_avail_hist_fields_2D
@@ -1698,10 +1734,9 @@ end subroutine write_2d_variables_parallel
 
 
 
-subroutine write_3d_and_4d_variables_parallel(ns, ncid)
+subroutine write_3d_and_4d_variables_parallel(ns, ncid, i_time)
 
-    integer, intent(in) :: ns
-    integer, intent(in) :: ncid
+    integer, intent(in) :: ns, ncid, i_time
 
     integer :: varid
     integer :: n, nn, k, ic
@@ -1709,7 +1744,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n2D + 1, n3Dccum
         nn = n - n2D
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_3d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     ncat_hist, a3Dc(:, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_3Dc
@@ -1718,7 +1753,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n3Dccum+1, n3Dzcum
         nn = n - n3Dccum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_3d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     nzilyr, a3Dz(:, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_3Dz
@@ -1727,7 +1762,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n3Dzcum+1, n3Dbcum
         nn = n - n3Dzcum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_3d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_3d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     nzblyr, a3Db(:, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_3Db
@@ -1736,7 +1771,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n3Dbcum+1, n4Dicum
         nn = n - n3Dbcum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_4d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     nzilyr, ncat_hist, a4Di(:, :, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_4Di
@@ -1745,7 +1780,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n4Dicum+1, n4Dscum
         nn = n - n4Dicum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_4d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     nzslyr, ncat_hist, a4Ds(:, :, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_4Ds
@@ -1753,7 +1788,7 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
     do n = n4Dscum+1, n4Dbcum
         nn = n - n4Dscum
         if (avail_hist_fields(n)%vhistfreq == histfreq(ns) .or. write_ic) then
-            call put_4d_with_blocks(ncid, avail_hist_fields(n)%vname, &
+            call put_4d_with_blocks(ncid, i_time, avail_hist_fields(n)%vname, &
                                     nzblyr, ncat_hist, a4Db(:, :, :, :, nn, :))
         endif
     enddo ! num_avail_hist_fields_4Db
@@ -1761,47 +1796,14 @@ subroutine write_3d_and_4d_variables_parallel(ns, ncid)
 end subroutine write_3d_and_4d_variables_parallel
 
 
-subroutine put_2d_with_blocks(ncid, var_name, data)
+subroutine put_2d_with_blocks(ncid, i_start, var_name, data)
 
-    integer, intent(in) :: ncid
+  ! by convention only, 2d variables are actually 3d if you consider time
+  ! sometimes the third array is a different index (e.g. number of bounds )
+
+    integer, intent(in) :: ncid, i_start
     character(len=*), intent(in) :: var_name
     real(kind=dbl_kind), dimension(nx_block, ny_block, max_blocks), intent(in) :: data
-
-    integer :: varid
-    integer :: iblk
-    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
-    integer, dimension(2) :: start, count
-    type(block) :: the_block
-
-    call check(nf90_inq_varid(ncid, var_name, varid), &
-               'inq varid for '//var_name)
-
-    do iblk=1, nblocks
-        the_block = get_block(blocks_ice(iblk), iblk)
-        ilo = the_block%ilo
-        jlo = the_block%jlo
-        ihi = the_block%ihi
-        jhi = the_block%jhi
-
-        gilo = the_block%i_glob(ilo)
-        gjlo = the_block%j_glob(jlo)
-        gihi = the_block%i_glob(ihi)
-        gjhi = the_block%j_glob(jhi)
-
-        start = (/ gilo, gjlo /)
-        count = (/ gihi - gilo + 1, gjhi - gjlo + 1 /)
-        call check(nf90_put_var(ncid, varid, real(data(ilo:ihi, jlo:jhi, iblk)), &
-                                start=start, count=count), &
-                    'put_2d_with_blocks put '//trim(var_name))
-    enddo
-
-end subroutine put_2d_with_blocks
-
-subroutine put_3d_with_blocks(ncid, var_name, len_3dim, data)
-
-    integer, intent(in) :: ncid, len_3dim
-    character(len=*), intent(in) :: var_name
-    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, max_blocks), intent(in) :: data
 
     integer :: varid
     integer :: iblk
@@ -1824,23 +1826,23 @@ subroutine put_3d_with_blocks(ncid, var_name, len_3dim, data)
         gihi = the_block%i_glob(ihi)
         gjhi = the_block%j_glob(jhi)
 
-        start = (/ gilo, gjlo, 1 /)
-        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim /)
-        call check(nf90_put_var(ncid, varid, &
-                                real(data(ilo:ihi, jlo:jhi, 1:len_3dim, iblk)), &
+        start = (/ gilo, gjlo,i_start /)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1 , 1/)
+        call check(nf90_put_var(ncid, varid, real(data(ilo:ihi, jlo:jhi, iblk)), &
                                 start=start, count=count), &
-                    'put_3d_with_blocks put '//trim(var_name))
+                    'put_2d_with_blocks put '//trim(var_name))
     enddo
 
-end subroutine put_3d_with_blocks
+end subroutine put_2d_with_blocks
+
+subroutine put_3d_with_blocks(ncid, i_time, var_name, len_3dim, data)
+
+  ! by convention only, 3d variables are actually 4d if you consider time
 
 
-subroutine put_4d_with_blocks(ncid, var_name, len_3dim, len_4dim, data)
-
-    integer, intent(in) :: ncid, len_3dim, len_4dim
+    integer, intent(in) :: ncid, i_time, len_3dim
     character(len=*), intent(in) :: var_name
-    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, &
-                                   len_4dim, max_blocks), intent(in) :: data
+    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, max_blocks), intent(in) :: data
 
     integer :: varid
     integer :: iblk
@@ -1863,8 +1865,49 @@ subroutine put_4d_with_blocks(ncid, var_name, len_3dim, len_4dim, data)
         gihi = the_block%i_glob(ihi)
         gjhi = the_block%j_glob(jhi)
 
-        start = (/ gilo, gjlo, 1, 1 /)
-        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim, len_4dim /)
+        start = (/ gilo, gjlo, 1 , i_time/)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim, 1 /)
+        call check(nf90_put_var(ncid, varid, &
+                                real(data(ilo:ihi, jlo:jhi, 1:len_3dim, iblk)), &
+                                start=start, count=count), &
+                    'put_3d_with_blocks put '//trim(var_name))
+    enddo
+
+end subroutine put_3d_with_blocks
+
+
+subroutine put_4d_with_blocks(ncid, i_time, var_name, len_3dim, len_4dim, data)
+  ! by convention only, 4d variables are actually 5d if you consider time
+
+
+    integer, intent(in) :: ncid, i_time, len_3dim, len_4dim
+    character(len=*), intent(in) :: var_name
+    real(kind=dbl_kind), dimension(nx_block, ny_block, len_3dim, &
+                                   len_4dim, max_blocks), intent(in) :: data
+
+    integer :: varid
+    integer :: iblk
+    integer :: ilo, jlo, ihi, jhi, gilo, gjlo, gihi, gjhi
+    integer, dimension(5) :: start, count
+    type(block) :: the_block
+
+    call check(nf90_inq_varid(ncid, var_name, varid), &
+               'inq varid for '//var_name)
+
+    do iblk=1, nblocks
+        the_block = get_block(blocks_ice(iblk), iblk)
+        ilo = the_block%ilo
+        jlo = the_block%jlo
+        ihi = the_block%ihi
+        jhi = the_block%jhi
+
+        gilo = the_block%i_glob(ilo)
+        gjlo = the_block%j_glob(jlo)
+        gihi = the_block%i_glob(ihi)
+        gjhi = the_block%j_glob(jhi)
+
+        start = (/ gilo, gjlo, 1, 1 , i_time/)
+        count = (/ gihi - gilo + 1, gjhi - gjlo + 1, len_3dim, len_4dim, 1 /)
         call check(nf90_put_var(ncid, varid, &
                                 real(data(ilo:ihi, jlo:jhi, 1:len_3dim, 1:len_4dim, iblk)), &
                                 start=start, count=count), &

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -186,7 +186,7 @@ end subroutine check
                        'inq varid time_bounds')
             if (history_parallel_io) then
               call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-                      'parallel access time')
+                      'parallel access time_bounds')
             endif
             call check(nf90_put_var(ncid,varid,time_beg(ns),start=(/1,i_time/)), &
                        'put var time_bounds beginning')
@@ -197,7 +197,8 @@ end subroutine check
 
     call broadcast_scalar(i_time, master_task) !we need this on every processor for parallel writes
     if (i_time == 1) then
-      ! these are time-invariant, only write once
+      ! these variables are time-invariant, only write once per file
+      ! ice_hist_create is only run on master task, but these variables are distributed, so call on all tasks
       !-----------------------------------------------------------------
       ! write coordinate variables
       !-----------------------------------------------------------------
@@ -247,9 +248,6 @@ end subroutine ice_write_hist
 subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
 
       use ice_calendar, only: idate, idate0, &
-! #ifdef ACCESS
-!         month, daymo, &
-! #endif
         dayyr, days_per_year, use_leap_years
       use ice_restart_shared, only: runid
 
@@ -1699,7 +1697,7 @@ subroutine write_grid_variables_parallel(ncid, var, var_nverts)
             call check(nf90_inq_varid(ncid, var_nverts(i)%short_name, varid), &
                        'inq varid '//var_nverts(i)%short_name)
             call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-                      'parallel access time')
+                      'parallel access '//var_nverts(i)%short_name)
 
             do iblk=1, nblocks
                 the_block = get_block(blocks_ice(iblk), iblk)
@@ -1825,8 +1823,8 @@ subroutine put_2d_with_blocks(ncid, i_start, var_name, data)
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
     call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-              'parallel access time')
-    
+              'parallel access '//var_name)
+
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)
         ilo = the_block%ilo
@@ -1866,7 +1864,7 @@ subroutine put_3d_with_blocks(ncid, i_time, var_name, len_3dim, data)
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
     call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-              'parallel access time')
+              'parallel access '//var_name)
 
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)
@@ -1909,7 +1907,7 @@ subroutine put_4d_with_blocks(ncid, i_time, var_name, len_3dim, len_4dim, data)
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
     call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-              'parallel access time')
+              'parallel access '//var_name)
 
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -70,11 +70,16 @@
 
 
 subroutine check(status, msg)
+    use ice_fileunits, only: nu_diag, ice_stderr, ice_stdout
     integer, intent (in) :: status
     character(len=*), intent (in) :: msg
 
     if(status /= nf90_noerr) then
-        call abort_ice('ice: NetCDF error '//trim(nf90_strerror(status)//' '//trim(msg)))
+        !sometimes the netcdf error string is quit long, so print seperately to prevent overrun
+        write(nu_diag,*) trim(nf90_strerror(status))
+        write (ice_stdout,*) trim(nf90_strerror(status))
+        write (ice_stderr,*) trim(nf90_strerror(status))
+        call abort_ice('ice: NetCDF error '//trim(msg))
     end if
 end subroutine check
 
@@ -100,6 +105,7 @@ end subroutine check
 
       real (kind=real_kind) :: ltime                 !history timestamp in seconds
       character (char_len_long) :: ncfile(max_nstrm) !filenames
+      character (char_len) :: time_string            !model time for logging
       logical :: file_exists
       integer (kind=int_kind) :: & 
         ncid,   &    ! netcdf id
@@ -130,7 +136,7 @@ end subroutine check
         ltime=time/int(secday)
 #endif
 
-        call construct_filename(ncfile(ns),'nc',ns)
+        call construct_filename(ncfile(ns),'nc',ns,time_string)
 
         ! add local directory path name to ncfile
         if (write_ic) then
@@ -141,9 +147,8 @@ end subroutine check
 
         inquire(file=trim(ncfile(ns)),exist=file_exists)
         if (.not. file_exists) then 
-          write(nu_diag,*) 'creating'//trim(ncfile(ns))
           call ice_hist_create(ns, ncfile(ns), ncid, var, coord_var, var_nverts, var_nz)
-          write(nu_diag,*) 'created'//trim(ncfile(ns))
+          write(nu_diag,*) 'Created:'//trim(ncfile(ns))
         else
           if (history_parallel_io) then
             call check(nf90_open(trim(ncfile(ns)), NF90_WRITE, ncid, &
@@ -180,6 +185,10 @@ end subroutine check
         if (hist_avg) then
             call check(nf90_inq_varid(ncid,'time_bounds',varid), &
                        'inq varid time_bounds')
+            if (history_parallel_io) then
+              call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+                      'parallel access time')
+            endif
             call check(nf90_put_var(ncid,varid,time_beg(ns),start=(/1,i_time/)), &
                        'put var time_bounds beginning')
             call check(nf90_put_var(ncid,varid,time_end(ns),start=(/2,i_time/)), &
@@ -231,7 +240,7 @@ end subroutine check
 
     if (my_task == master_task .or. history_parallel_io) then
         call check(nf90_close(ncid), 'closing netCDF history file')
-        write(nu_diag,*) 'Finished writing ',trim(ncfile(ns)),' at time'
+        write(nu_diag,*) 'Wrote ',trim(ncfile(ns)),' at time ',trim(time_string)
     endif
 
 end subroutine ice_write_hist
@@ -1200,7 +1209,6 @@ subroutine write_coordinate_variables(ncid, coord_var, var_nz)
 end subroutine write_coordinate_variables
 
 
-
 subroutine write_grid_variables(ncid, var, var_nverts)
 
     integer, intent(in) :: ncid
@@ -1597,6 +1605,8 @@ subroutine write_coordinate_variables_parallel(ncid, coord_var, var_nz)
         if (igrdz(i)) then
             call check(nf90_inq_varid(ncid, var_nz(i)%short_name, varid), &
                         'inq_varid '//var_nz(i)%short_name)
+            call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+                      'parallel access time')
             SELECT CASE (var_nz(i)%short_name)
             CASE ('NCAT')
                 call check(nf90_put_var(ncid, varid, hin_max(1:ncat_hist)), &
@@ -1690,6 +1700,8 @@ subroutine write_grid_variables_parallel(ncid, var, var_nverts)
 
             call check(nf90_inq_varid(ncid, var_nverts(i)%short_name, varid), &
                        'inq varid '//var_nverts(i)%short_name)
+            call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+                      'parallel access time')
 
             do iblk=1, nblocks
                 the_block = get_block(blocks_ice(iblk), iblk)
@@ -1813,7 +1825,9 @@ subroutine put_2d_with_blocks(ncid, i_start, var_name, data)
 
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
-
+    call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+              'parallel access time')
+    
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)
         ilo = the_block%ilo
@@ -1852,6 +1866,8 @@ subroutine put_3d_with_blocks(ncid, i_time, var_name, len_3dim, data)
 
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
+    call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+              'parallel access time')
 
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)
@@ -1893,6 +1909,8 @@ subroutine put_4d_with_blocks(ncid, i_time, var_name, len_3dim, len_4dim, data)
 
     call check(nf90_inq_varid(ncid, var_name, varid), &
                'inq varid for '//var_name)
+    call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
+              'parallel access time')
 
     do iblk=1, nblocks
         the_block = get_block(blocks_ice(iblk), iblk)

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -246,11 +246,11 @@ end subroutine ice_write_hist
 
 subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
 
-      use ice_calendar, only: idate, idate0
+      use ice_calendar, only: idate, idate0, &
 ! #ifdef ACCESS
 !         month, daymo, &
 ! #endif
-!         dayyr, days_per_year, use_leap_years
+        dayyr, days_per_year, use_leap_years
       use ice_restart_shared, only: runid
 
       integer (kind=int_kind), intent(in) :: ns

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -38,6 +38,7 @@
     use ice_history_shared
     use ice_itd, only: hin_max
     use ice_calendar, only: write_ic, histfreq
+    use ice_fileunits, only: nu_diag, ice_stderr, ice_stdout
 
 
       implicit none
@@ -70,7 +71,6 @@
 
 
 subroutine check(status, msg)
-    use ice_fileunits, only: nu_diag, ice_stderr, ice_stdout
     integer, intent (in) :: status
     character(len=*), intent (in) :: msg
 
@@ -97,7 +97,6 @@ end subroutine check
         month, daymo, &
 #endif
         dayyr, days_per_year, use_leap_years
-      use ice_fileunits, only: nu_diag
 
       integer (kind=int_kind), intent(in) :: ns !history stream number
 
@@ -247,12 +246,11 @@ end subroutine ice_write_hist
 
 subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
 
-      use ice_calendar, only: time, sec, idate, idate0, &
-#ifdef ACCESS
-        month, daymo, &
-#endif
-        dayyr, days_per_year, use_leap_years
-      use ice_fileunits, only: nu_diag
+      use ice_calendar, only: idate, idate0
+! #ifdef ACCESS
+!         month, daymo, &
+! #endif
+!         dayyr, days_per_year, use_leap_years
       use ice_restart_shared, only: runid
 
       integer (kind=int_kind), intent(in) :: ns
@@ -1606,7 +1604,7 @@ subroutine write_coordinate_variables_parallel(ncid, coord_var, var_nz)
             call check(nf90_inq_varid(ncid, var_nz(i)%short_name, varid), &
                         'inq_varid '//var_nz(i)%short_name)
             call check(nf90_var_par_access(ncid, varid, NF90_COLLECTIVE), &
-                      'parallel access time')
+                      'parallel access '//var_nz(i)%short_name)
             SELECT CASE (var_nz(i)%short_name)
             CASE ('NCAT')
                 call check(nf90_put_var(ncid, varid, hin_max(1:ncat_hist)), &
@@ -1812,6 +1810,7 @@ subroutine put_2d_with_blocks(ncid, i_start, var_name, data)
 
   ! by convention only, 2d variables are actually 3d if you consider time
   ! sometimes the third array is a different index (e.g. number of bounds )
+  ! typically i_start is the current time index, but can be different
 
     integer, intent(in) :: ncid, i_start
     character(len=*), intent(in) :: var_name

--- a/source/ice_calendar.F90
+++ b/source/ice_calendar.F90
@@ -111,8 +111,9 @@
          write_history(max_nstrm) ! write history now
 
       character (len=1), public :: &
-         histfreq(max_nstrm), & ! history output frequency, 'y','m','d','h','1'
-         dumpfreq               ! restart frequency, 'y','m','d'
+         histfreq(max_nstrm),       & ! history output frequency, 'y','m','d','h','1'
+         hist_file_freq(max_nstrm), & ! history output file save frequency, 'y','m','d','h','1'
+         dumpfreq                     ! restart frequency, 'y','m','d'
 
       character (len=char_len),public :: calendar_type
 

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -612,7 +612,6 @@
       integer (kind=int_kind), intent(in) :: ns
 
       integer (kind=int_kind) :: iyear, imonth, iday, isec
-      character (len=1) :: cstream
 
         iyear = nyr + year_init - 1 ! set year_init=1 in ice_in to get iyear=nyr
         imonth = month
@@ -624,7 +623,7 @@
 #endif
         ! construct filename
         if (write_ic) then
-            ncfile=incond_file(1:lenstr(incond_file))//'.'
+            ncfile=incond_file(1:lenstr(incond_file))
             write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
                iyear,'-',imonth,'-',iday,'-',sec
         else
@@ -646,45 +645,40 @@
 
          ncfile=history_file(1:lenstr(history_file))
 
-         ! frequency of history ouput (typicall 1)
+         ! frequency of history ouput (typically 1)
          if (histfreq_n(ns)>9) then
             write(ldate_string,'(i2)') histfreq_n(ns)  
          else
             write(ldate_string,'(i1)') histfreq_n(ns)  
          endif
 
-         !name file based on history frequency (e.g. "daily-mean")
-         if (histfreq(ns) == '1') then ! instantaneous, write every dt
-            ncfile=ncfile(1:lenstr(ncfile))//'-snap'
-         elseif (hist_avg) then    ! write averaged data
-            ncfile=ncfile(1:lenstr(ncfile))//'-'//trim(ldate_string)
-            if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
-               ncfile=ncfile(1:lenstr(ncfile))//'daily-mean'
-            elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
-               ncfile=ncfile(1:lenstr(ncfile))//'hourly-mean'
-            elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
-               ncfile=ncfile(1:lenstr(ncfile))//'monthly-mean'
-            elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
-               ncfile=ncfile(1:lenstr(ncfile))//'yearly-mean'
-            endif
+         ! name file based on history frequency (e.g. "daily-mean")
+         if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
+            ncfile=ncfile(1:lenstr(ncfile))//'daily'
+         elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
+            ncfile=ncfile(1:lenstr(ncfile))//'hourly'
+         elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
+            ncfile=ncfile(1:lenstr(ncfile))//'monthly'
+         elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
+            ncfile=ncfile(1:lenstr(ncfile))//'yearly'
+
+         if (hist_avg) then
+            ncfile=ncfile(1:lenstr(ncfile))//'-mean'
          else                     ! instantaneous with histfreq > dt
-           ncfile=ncfile(1:lenstr(ncfile))//'-snap'
+            ncfile=ncfile(1:lenstr(ncfile))//'-snap'
          endif
 
-         !date in filename is based on history file output frequency (e.g. "0001-01")
+         ! date in filename is based on history file output frequency (e.g. "0001-01" for one file per month)
          if (hist_file_freq(ns) == 'd'.or.hist_file_freq(ns) == 'D') then     ! daily
-            write(ldate_string,'(i4.4,a,i2.2,a,i2.2)')  &
-                  iyear,'-',imonth,'-',iday
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2)') iyear,'-',imonth,'-',iday
          elseif (hist_file_freq(ns) == 'h'.or.hist_file_freq(ns) == 'H') then ! hourly
-            write(ldate_string,'(i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
-               iyear,'-',imonth,'-',iday,'-',sec
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') iyear,'-',imonth,'-',iday,'-',sec
          elseif (hist_file_freq(ns) == 'm'.or.hist_file_freq(ns) == 'M') then ! monthly
             write(ldate_string,'(i4.4,a,i2.2)') iyear,'-',imonth
          elseif (hist_file_freq(ns) == 'y'.or.hist_file_freq(ns) == 'Y') then ! yearly
-            write(ldate_string,'(i4.4,a,a)') iyear
+            write(ldate_string,'(i4.4)') iyear
          else !instantaneous
-            write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
-                 iyear,'-',imonth,'-',iday,'-',sec
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)') iyear,'-',imonth,'-',iday,'-',sec
          endif
 
         endif

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -652,6 +652,8 @@
             write(ldate_string,'(i1)') histfreq_n(ns)  
          endif
 
+         ncfile=ncfile(1:lenstr(ncfile))//'-'//trim(ldate_string)
+
          ! name file based on history frequency (e.g. "daily-mean")
          if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
             ncfile=ncfile(1:lenstr(ncfile))//'daily'
@@ -665,7 +667,7 @@
 
          if (hist_avg) then
             ncfile=ncfile(1:lenstr(ncfile))//'-mean'
-         else                     ! instantaneous with histfreq > dt
+         else
             ncfile=ncfile(1:lenstr(ncfile))//'-snap'
          endif
 

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -661,6 +661,7 @@
             ncfile=ncfile(1:lenstr(ncfile))//'monthly'
          elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
             ncfile=ncfile(1:lenstr(ncfile))//'yearly'
+         endif
 
          if (hist_avg) then
             ncfile=ncfile(1:lenstr(ncfile))//'-mean'

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -593,7 +593,11 @@
 
 !=======================================================================
 
-      subroutine construct_filename(ncfile,suffix,ns)
+      subroutine construct_filename(ncfile,suffix,ns,time_string)
+
+      ! construct filenames for history output
+      ! we follow cosima convention:
+      ! e.g. ice-1daily-mean_0001-01.nc for daily data in january 0001
 
       use ice_calendar, only: time, sec, nyr, month, daymo,  &
                               mday, write_ic, histfreq, hist_file_freq, histfreq_n, &
@@ -602,14 +606,15 @@
       use ice_restart_shared, only: lenstr
 
       character (char_len_long), intent(inout) :: ncfile
-      character (char_len) :: date_string
+      character (char_len), intent(out), optional :: time_string
+      character (char_len) :: ldate_string
       character (len=2), intent(in) :: suffix
       integer (kind=int_kind), intent(in) :: ns
 
       integer (kind=int_kind) :: iyear, imonth, iday, isec
       character (len=1) :: cstream
 
-      iyear = nyr + year_init - 1 ! set year_init=1 in ice_in to get iyear=nyr
+        iyear = nyr + year_init - 1 ! set year_init=1 in ice_in to get iyear=nyr
         imonth = month
         iday = mday
         isec = sec - dt
@@ -619,9 +624,9 @@
 #endif
         ! construct filename
         if (write_ic) then
-           write(ncfile,'(a,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-              incond_file(1:lenstr(incond_file)),'.',iyear,'-', &
-              imonth,'-',iday,'-',isec,'.',suffix
+            ncfile=incond_file(1:lenstr(incond_file))//'.'
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
+               iyear,'-',imonth,'-',iday,'-',sec
         else
 
          if (hist_avg .and. histfreq(ns) /= '1') then
@@ -641,39 +646,56 @@
 
          ncfile=history_file(1:lenstr(history_file))
 
+         ! frequency of history ouput (typicall 1)
+         if (histfreq_n(ns)>9) then
+            write(ldate_string,'(i2)') histfreq_n(ns)  
+         else
+            write(ldate_string,'(i1)') histfreq_n(ns)  
+         endif
+
+         !name file based on history frequency (e.g. "daily-mean")
          if (histfreq(ns) == '1') then ! instantaneous, write every dt
-            ncfile=ncfile(1:lenstr(ncfile))//'_inst.'
+            ncfile=ncfile(1:lenstr(ncfile))//'-snap'
          elseif (hist_avg) then    ! write averaged data
+            ncfile=ncfile(1:lenstr(ncfile))//'-'//trim(ldate_string)
             if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
-               ncfile=ncfile(1:lenstr(ncfile))//'_d.'
+               ncfile=ncfile(1:lenstr(ncfile))//'daily-mean'
             elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
-               write(date_string,'(i2.2)') histfreq_n(ns)
-               ncfile=ncfile(1:lenstr(ncfile))//'_'//date_string(1:len(date_string))//'h.'
+               ncfile=ncfile(1:lenstr(ncfile))//'hourly-mean'
             elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
-               ncfile=ncfile(1:lenstr(ncfile))//'_m.'
+               ncfile=ncfile(1:lenstr(ncfile))//'monthly-mean'
             elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
-               ncfile=ncfile(1:lenstr(ncfile))//'_y.'
+               ncfile=ncfile(1:lenstr(ncfile))//'yearly-mean'
             endif
          else                     ! instantaneous with histfreq > dt
-           ncfile=ncfile(1:lenstr(ncfile))//'_inst.'
+           ncfile=ncfile(1:lenstr(ncfile))//'-snap'
          endif
 
+         !date in filename is based on history file output frequency (e.g. "0001-01")
          if (hist_file_freq(ns) == 'd'.or.hist_file_freq(ns) == 'D') then     ! daily
-            write(date_string,'(i4.4,a,i2.2,a,i2.2,a,a)')  &
-                  iyear,'-',imonth,'-',iday,'.',suffix
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2)')  &
+                  iyear,'-',imonth,'-',iday
          elseif (hist_file_freq(ns) == 'h'.or.hist_file_freq(ns) == 'H') then ! hourly
-            write(date_string,'(i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-               iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+            write(ldate_string,'(i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
+               iyear,'-',imonth,'-',iday,'-',sec
          elseif (hist_file_freq(ns) == 'm'.or.hist_file_freq(ns) == 'M') then ! monthly
-            write(date_string,'(i4.4,a,i2.2,a,a)') iyear,'-',imonth,'.',suffix
+            write(ldate_string,'(i4.4,a,i2.2)') iyear,'-',imonth
          elseif (hist_file_freq(ns) == 'y'.or.hist_file_freq(ns) == 'Y') then ! yearly
-            write(date_string,'(i4.4,a,a)') iyear,'.',suffix
+            write(ldate_string,'(i4.4,a,a)') iyear
          else !instantaneous
-            write(date_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-                 iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+            write(ldate_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
+                 iyear,'-',imonth,'-',iday,'-',sec
          endif
 
-         ncfile=ncfile(1:lenstr(ncfile))//date_string(1:lenstr(date_string))
+        endif
+
+        ! join the pieces, typically iceh-1daily-mean_0001-01.nc
+        ncfile=ncfile(1:lenstr(ncfile))//'_'//ldate_string(1:lenstr(ldate_string))//'.'//suffix
+
+        ! create a string of current time for debugging
+        if ( present(time_string) ) then
+            write(time_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5)')  &
+                 iyear,'-',imonth,'-',iday,'-',sec
         endif
 
       end subroutine construct_filename

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -25,7 +25,6 @@
       module ice_history_shared
 
       use ice_kinds_mod
-      use ice_fileunits, only: nu_diag
       use ice_domain_size, only: ncat, nilyr, nslyr, nblyr, max_nstrm
 
       implicit none
@@ -597,12 +596,13 @@
       subroutine construct_filename(ncfile,suffix,ns)
 
       use ice_calendar, only: time, sec, nyr, month, daymo,  &
-                              mday, write_ic, histfreq, histfreq_n, &
+                              mday, write_ic, histfreq, hist_file_freq, histfreq_n, &
                               year_init, new_year, new_month, new_day, &
                               dt
       use ice_restart_shared, only: lenstr
 
       character (char_len_long), intent(inout) :: ncfile
+      character (char_len) :: date_string
       character (len=2), intent(in) :: suffix
       integer (kind=int_kind), intent(in) :: ns
 
@@ -639,42 +639,41 @@
           endif
          endif
 
-         cstream = ''
-         if (ns > 10) write(cstream,'(i1.1)') ns-1
-! ABK: Disable the addition of a stream number to the history file
-! (now only occurs for more than 10 streams, which is v unlikely!)
+         ncfile=history_file(1:lenstr(history_file))
 
          if (histfreq(ns) == '1') then ! instantaneous, write every dt
-           write(ncfile,'(a,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-            history_file(1:lenstr(history_file))//trim(cstream),'_inst.', &
-            iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
-
+            ncfile=ncfile(1:lenstr(ncfile))//'_inst.'
          elseif (hist_avg) then    ! write averaged data
-
-          if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
-           write(ncfile,'(a,a,i4.4,a,i2.2,a,i2.2,a,a)')  &
-           history_file(1:lenstr(history_file))//trim(cstream), &
-             '.',iyear,'-',imonth,'-',iday,'.',suffix
-          elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
-           write(ncfile,'(a,a,i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-            history_file(1:lenstr(history_file))//trim(cstream),'_', &
-            histfreq_n(ns),'h.',iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
-
-          elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
-           write(ncfile,'(a,a,i4.4,a,i2.2,a,a)')  &
-            history_file(1:lenstr(history_file))//trim(cstream),'.', &
-             iyear,'-',imonth,'.',suffix
-          elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
-           write(ncfile,'(a,a,i4.4,a,a)') &
-            history_file(1:lenstr(history_file))//trim(cstream),'.', &
-          iyear,'.',suffix
-          endif
-
+            if (histfreq(ns) == 'd'.or.histfreq(ns) == 'D') then     ! daily
+               ncfile=ncfile(1:lenstr(ncfile))//'_d.'
+            elseif (histfreq(ns) == 'h'.or.histfreq(ns) == 'H') then ! hourly
+               write(date_string,'(i2.2)') histfreq_n(ns)
+               ncfile=ncfile(1:lenstr(ncfile))//'_'//date_string(1:len(date_string))//'h.'
+            elseif (histfreq(ns) == 'm'.or.histfreq(ns) == 'M') then ! monthly
+               ncfile=ncfile(1:lenstr(ncfile))//'_m.'
+            elseif (histfreq(ns) == 'y'.or.histfreq(ns) == 'Y') then ! yearly
+               ncfile=ncfile(1:lenstr(ncfile))//'_y.'
+            endif
          else                     ! instantaneous with histfreq > dt
-           write(ncfile,'(a,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
-            history_file(1:lenstr(history_file)),'_inst.', &
-             iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+           ncfile=ncfile(1:lenstr(ncfile))//'_inst.'
          endif
+
+         if (hist_file_freq(ns) == 'd'.or.hist_file_freq(ns) == 'D') then     ! daily
+            write(date_string,'(i4.4,a,i2.2,a,i2.2,a,a)')  &
+                  iyear,'-',imonth,'-',iday,'.',suffix
+         elseif (hist_file_freq(ns) == 'h'.or.hist_file_freq(ns) == 'H') then ! hourly
+            write(date_string,'(i2.2,a,i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
+               iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+         elseif (hist_file_freq(ns) == 'm'.or.hist_file_freq(ns) == 'M') then ! monthly
+            write(date_string,'(i4.4,a,i2.2,a,a)') iyear,'-',imonth,'.',suffix
+         elseif (hist_file_freq(ns) == 'y'.or.hist_file_freq(ns) == 'Y') then ! yearly
+            write(date_string,'(i4.4,a,a)') iyear,'.',suffix
+         else !instantaneous
+            write(date_string,'(i4.4,a,i2.2,a,i2.2,a,i5.5,a,a)')  &
+                 iyear,'-',imonth,'-',iday,'-',sec,'.',suffix
+         endif
+
+         ncfile=ncfile(1:lenstr(ncfile))//date_string(1:lenstr(date_string))
         endif
 
       end subroutine construct_filename

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -736,7 +736,7 @@
       !if hist_file_freq not set, default to histfreq
       if (my_task == master_task) then
          do n = 1, max_nstrm
-            if (hist_file_freq(n)=='x' .or. hist_file_freq(ns) == 'D') hist_file_freq(n) = histfreq(n)
+            if (hist_file_freq(n)=='x' .or. hist_file_freq(n) == 'X') hist_file_freq(n) = histfreq(n)
          enddo
       endif
 

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -733,7 +733,7 @@
       endif
 #endif
 
-      !is hist file freq not set, defailt to histfreq
+      !if hist_file_freq not set, default to histfreq
       if (my_task == master_task) then
          do n = 1, max_nstrm
             if (hist_file_freq(n)=='x') hist_file_freq(n) = histfreq(n)

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -51,7 +51,7 @@
       use ice_calendar, only: year_init, istep0, histfreq, histfreq_n, &
                               dumpfreq, dumpfreq_n, diagfreq, nstreams, &
                               npt, dt, ndtd, days_per_year, use_leap_years, &
-                              write_ic, dump_last
+                              write_ic, dump_last, hist_file_freq
       use ice_restart_shared, only: &
           restart, restart_ext, restart_dir, restart_file, pointer_file, &
           runid, runtype, use_restart_time, restart_format
@@ -134,6 +134,7 @@
         diagfreq,       diag_type,      diag_file,                      &
         print_global,   print_points,   latpnt,          lonpnt,        &
         dbug,           histfreq,       histfreq_n,      hist_avg,      &
+        hist_file_freq,                                                 &
         history_dir,    history_file,   history_deflate_level,          &
         history_parallel_io, history_chunksize_x, history_chunksize_y,  &
         write_ic,       incond_dir,     incond_file
@@ -222,6 +223,7 @@
       histfreq(4) = 'm'      ! output frequency option for different streams
       histfreq(5) = 'y'      ! output frequency option for different streams
       histfreq_n(:) = 1      ! output frequency 
+      hist_file_freq(:) = 'x' ! default to histfreq (below)
       hist_avg = .true.      ! if true, write time-averages (not snapshots)
       history_dir  = './'    ! write to executable dir for default
       history_file = 'iceh'  ! history file name prefix
@@ -731,6 +733,13 @@
       endif
 #endif
 
+      !is hist file freq not set, defailt to histfreq
+      if (my_task == master_task) then
+         do n = 1, max_nstrm
+            if (hist_file_freq(n)=='x') hist_file_freq(n) = histfreq(n)
+         enddo
+      endif
+
       call broadcast_scalar(days_per_year,      master_task)
       call broadcast_scalar(use_leap_years,     master_task)
       call broadcast_scalar(year_init,          master_task)
@@ -745,7 +754,10 @@
       call broadcast_scalar(diag_file,          master_task)
       do n = 1, max_nstrm
          call broadcast_scalar(histfreq(n),     master_task)
-      enddo  
+      enddo
+      do n = 1, max_nstrm
+         call broadcast_scalar(hist_file_freq(n),     master_task)
+      enddo
       call broadcast_array(histfreq_n,          master_task)
       call broadcast_scalar(hist_avg,           master_task)
       call broadcast_scalar(history_dir,        master_task)
@@ -916,6 +928,7 @@
          write(nu_diag,1010) ' print_points              = ', print_points
          write(nu_diag,1010) ' bfbflag                   = ', bfbflag
          write(nu_diag,1050) ' histfreq                  = ', histfreq(:)
+         write(nu_diag,1050) ' hist_file_freq            = ', hist_file_freq(:)
          write(nu_diag,1040) ' histfreq_n                = ', histfreq_n(:)
          write(nu_diag,1010) ' hist_avg                  = ', hist_avg
          if (.not. hist_avg) write (nu_diag,*) 'History data will be snapshots'
@@ -923,8 +936,10 @@
                                trim(history_dir)
          write(nu_diag,*)    ' history_file              = ', &
                                trim(history_file)
-         write(nu_diag,*)    ' history_deflate_level     = ', &
+         write(nu_diag,1020) ' history_deflate_level     = ', &
                                history_deflate_level
+         write(nu_diag,1010) ' history_parallel_io       = ', &
+                               history_parallel_io
          if (write_ic) then
             write (nu_diag,*) 'Initial condition will be written in ', &
                                trim(incond_dir)

--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -736,7 +736,7 @@
       !if hist_file_freq not set, default to histfreq
       if (my_task == master_task) then
          do n = 1, max_nstrm
-            if (hist_file_freq(n)=='x') hist_file_freq(n) = histfreq(n)
+            if (hist_file_freq(n)=='x' .or. hist_file_freq(ns) == 'D') hist_file_freq(n) = histfreq(n)
          enddo
       endif
 


### PR DESCRIPTION
This change add the namelist argument `hist_file_freq`. It is a array of 5 chars (like `histfreq`) and defaults to the same value as `histfreq`. `hist_file_freq` is the frequency of history files to output and allows the file frequency to be seperate from the history frequency (e.g. allows output of daily data in one file per month).

e.g.:

```
    histfreq       = 'd','m','x','x','x'
    hist_file_freq = 'm','y','x','x','x'
```

outputs daily data in one file per month, and monthly data in one file per month. if the run length is less than hist_file_freq, the data is still saved.

This is implemented by:

- splitting some of `ice_write_hist` into a new subroutine `ice_hist_create`. `ice_hist_create` handles creating dimensions, coordinates and meta-data for a history file. `ice_write_hist` still has the code for adding data.
- `construct_filename` is changed to construct the filename based on `hist_file_freq`. e.g. daily data for January is written to `iceh-daily_0786-01.nc` and monthly data for year 786 is written to `iceh_monthly_0786`
- changing the file names to follow ocean conventions (e.g. `iceh-daily_0786-01.nc` instead of `iceh_d.0786-01.nc` (the new names will break the intake builder).


This doesn't address re-aligning the data for data access e.g with chunks along time dimension. It also repeated opens and closes the same file (before/after every write), which is inefficient but no worse than the current behaviour (which always creates a new file). 

p.s.

To support the netcdf parallel implementation (which is unused), I set collective access to true for all variables

The docs say this:

> Collective/Independent Access
> 
> Parallel file access is either collective (all processors must participate) or independent (any processor may access the data without waiting for others). All netCDF metadata writing operations are collective. That is, all creation of groups, types, variables, dimensions, or attributes. Data reads and writes (e.g. calls to [nc_put_vara_int()](https://docs.unidata.ucar.edu/netcdf-c/4.9.2/group__variables.html#ga45ad87d40fe9d032baa4705bffe8c1dc) and [nc_get_vara_int()](https://docs.unidata.ucar.edu/netcdf-c/4.9.2/group__variables.html#gaa109955db46f2dd6bab83ae7d53c7750)) may be independent, the default) or collective. To change from collective to independent mode or vis versa, call [nc_var_par_access()](https://docs.unidata.ucar.edu/netcdf-c/4.9.2/group__datasets.html#ga6dc46e4ab82584360518db5cb0cad841) with argument 'access' set to either NC_INDEPENDENT or NC_COLLECTIVE. Note when using PnetCDF, the argument 'varid' is ignored, as PnetCDF does not support per-variable collective/independent mode change.


Its possible that has the impact impacted timing when setting `history_parallel_io = .true.` ? (but we don't use this currently, so i didn't investigate.)

Contributes to #58 