### PR TITLE
`build-ci v3`: Update Infra For `spack v1`

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,7 +1,7 @@
 {
     "gcc_compiler": "gcc@13.2.0",
-    "intel_compiler": "intel@2021.10.0",
-    "oneapi_compiler": "oneapi@2025.2.0",
+    "intel_compiler": "intel-oneapi-compilers-classic@2021.10.0",
+    "oneapi_compiler": "intel-oneapi-compilers@2025.2.0",
     "om2_1deg": "build_system=cmake model=access-om2 nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1",
     "esm1p6": "build_system=cmake model=access-esm1.6 nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1",
     "target": "x86_64"

--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,7 +1,7 @@
 {
-    "gcc_compiler": "gcc@13.2.0",
-    "intel_compiler": "intel-oneapi-compilers-classic@2021.10.0",
-    "oneapi_compiler": "intel-oneapi-compilers@2025.2.0",
+    "gcc_compiler_ver": "@13.2.0",
+    "intel_compiler_ver": "@2021.10.0",
+    "oneapi_compiler_ver": "@2025.2.0",
     "om2_1deg": "build_system=cmake model=access-om2 nxglob=360 nyglob=300 blckx=15 blcky=300 mxblcks=1",
     "esm1p6": "build_system=cmake model=access-esm1.6 nxglob=360 nyglob=300 blckx=30 blcky=300 mxblcks=1",
     "target": "x86_64"

--- a/.github/build-ci/manifests/gcc-cice5-cmake.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5-cmake.spack.yaml.j2
@@ -2,9 +2,17 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }}'
   packages:
-    all:
+    c:
       require:
-      - '%{{ gcc_compiler }}'
+      - {{ gcc_compiler }}
+    cxx:
+      require:
+      - {{ gcc_compiler }}
+    fortran:
+      require:
+      - {{ gcc_compiler }}
+    all:
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/gcc-cice5-cmake.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5-cmake.spack.yaml.j2
@@ -2,17 +2,12 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }}'
   packages:
-    c:
+    gcc:
       require:
-      - {{ gcc_compiler }}
-    cxx:
-      require:
-      - {{ gcc_compiler }}
-    fortran:
-      require:
-      - {{ gcc_compiler }}
+      - '{{ gcc_compiler_ver }}'
     all:
       prefer:
+      - '%access_gcc'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/gcc-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5-makefile.spack.yaml.j2
@@ -2,9 +2,17 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
-    all:
+    c:
       require:
-      - '%{{ gcc_compiler }}'
+      - {{ gcc_compiler }}
+    cxx:
+      require:
+      - {{ gcc_compiler }}
+    fortran:
+      require:
+      - {{ gcc_compiler }}
+    all:
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/gcc-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5-makefile.spack.yaml.j2
@@ -2,17 +2,12 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
-    c:
+    gcc:
       require:
-      - {{ gcc_compiler }}
-    cxx:
-      require:
-      - {{ gcc_compiler }}
-    fortran:
-      require:
-      - {{ gcc_compiler }}
+      - '{{ gcc_compiler_ver }}'
     all:
       prefer:
+      - '%access_gcc'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel-cice5-cmake.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5-cmake.spack.yaml.j2
@@ -3,9 +3,17 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }}'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
   packages:
-    all:
+    c:
       require:
-      - '%{{ intel_compiler }}'
+      - {{ intel_compiler }}
+    cxx:
+      require:
+      - {{ intel_compiler }}
+    fortran:
+      require:
+      - {{ intel_compiler }}
+    all:
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel-cice5-cmake.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5-cmake.spack.yaml.j2
@@ -3,17 +3,12 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }}'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
   packages:
-    c:
+    intel-oneapi-compilers-classic:
       require:
-      - {{ intel_compiler }}
-    cxx:
-      require:
-      - {{ intel_compiler }}
-    fortran:
-      require:
-      - {{ intel_compiler }}
+      - '{{ intel_compiler_ver }}'
     all:
       prefer:
+      - '%access_intel'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5-makefile.spack.yaml.j2
@@ -2,9 +2,17 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
-    all:
+    c:
       require:
-      - '%{{ intel_compiler }}'
+      - {{ intel_compiler }}
+    cxx:
+      require:
+      - {{ intel_compiler }}
+    fortran:
+      require:
+      - {{ intel_compiler }}
+    all:
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/intel-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5-makefile.spack.yaml.j2
@@ -2,17 +2,12 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
-    c:
+    intel-oneapi-compilers-classic:
       require:
-      - {{ intel_compiler }}
-    cxx:
-      require:
-      - {{ intel_compiler }}
-    fortran:
-      require:
-      - {{ intel_compiler }}
+      - '{{ intel_compiler_ver }}'
     all:
       prefer:
+      - '%access_intel'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-cmake-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-cmake-esm1p6.spack.yaml.j2
@@ -4,17 +4,12 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ esm1p6 }} ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ esm1p6 }}'
   packages:
-    c:
+    intel-oneapi-compilers:
       require:
-      - {{ oneapi_compiler }}
-    cxx:
-      require:
-      - {{ oneapi_compiler }}
-    fortran:
-      require:
-      - {{ oneapi_compiler }}
+      - '{{ oneapi_compiler_ver }}'
     all:
       prefer:
+      - '%access_oneapi'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-cmake-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-cmake-esm1p6.spack.yaml.j2
@@ -4,12 +4,17 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ esm1p6 }} ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ esm1p6 }}'
   packages:
-    gcc-runtime:
+    c:
       require:
-        '%gcc'
+      - {{ oneapi_compiler }}
+    cxx:
+      require:
+      - {{ oneapi_compiler }}
+    fortran:
+      require:
+      - {{ oneapi_compiler }}
     all:
-      require:
-      - '%{{ oneapi_compiler }}'
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-cmake-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-cmake-om2.spack.yaml.j2
@@ -4,12 +4,17 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }} io_type=NetCDF ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
   packages:
-    gcc-runtime:
+    c:
       require:
-        '%gcc'
+      - {{ oneapi_compiler }}
+    cxx:
+      require:
+      - {{ oneapi_compiler }}
+    fortran:
+      require:
+      - {{ oneapi_compiler }}
     all:
-      require:
-      - '%{{ oneapi_compiler }}'
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-cmake-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-cmake-om2.spack.yaml.j2
@@ -4,17 +4,12 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }} io_type=NetCDF ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
   packages:
-    c:
+    intel-oneapi-compilers:
       require:
-      - {{ oneapi_compiler }}
-    cxx:
-      require:
-      - {{ oneapi_compiler }}
-    fortran:
-      require:
-      - {{ oneapi_compiler }}
+      - '{{ oneapi_compiler_ver }}'
     all:
       prefer:
+      - '%access_oneapi'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-makefile.spack.yaml.j2
@@ -3,17 +3,12 @@ spack:
   - 'cice5@git.{{ ref }}=stable model=access-om2 ^openmpi@4'
   - 'cice5@git.{{ ref }}=stable model=access-om2 ^openmpi@5'
   packages:
-    c:
+    intel-oneapi-compilers:
       require:
-      - {{ oneapi_compiler }}
-    cxx:
-      require:
-      - {{ oneapi_compiler }}
-    fortran:
-      require:
-      - {{ oneapi_compiler }}
+      - '{{ oneapi_compiler_ver }}'
     all:
       prefer:
+      - '%access_oneapi'
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/build-ci/manifests/oneapi-cice5-makefile.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-makefile.spack.yaml.j2
@@ -3,12 +3,17 @@ spack:
   - 'cice5@git.{{ ref }}=stable model=access-om2 ^openmpi@4'
   - 'cice5@git.{{ ref }}=stable model=access-om2 ^openmpi@5'
   packages:
-    gcc-runtime:
+    c:
       require:
-        '%gcc'
+      - {{ oneapi_compiler }}
+    cxx:
+      require:
+      - {{ oneapi_compiler }}
+    fortran:
+      require:
+      - {{ oneapi_compiler }}
     all:
-      require:
-      - '%{{ oneapi_compiler }}'
+      prefer:
       - 'target={{ target }}'
   concretizer:
     unify: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
       # builtin-spack-packages-ref: main
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v1.0
+      # spack-ref: releases/v1.1
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      # builtin-spack-packages-ref: main
-      # access-spack-packages-ref: api-v2
-      # spack-config-ref: main
-      # spack-ref: releases/v1.1
+      # Default args (including explicit spack/spack-packages/spack-config versions)
+      # are specified in https://github.com/ACCESS-NRI/build-ci/tree/v3/.github/workflows#inputs
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,14 @@ jobs:
       max-parallel: 5
       matrix:
         file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      # spack-packages-ref: main
+      # builtin-spack-packages-ref: main
+      # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v0.22
+      # spack-ref: releases/v1.0
     secrets:
       spack-install-command-pat: ${{ secrets.SPACK_INSTALL_COMMAND_PAT }}


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Determine if a specific `builtin-spack-packages-ref` is required
- [x] Determine if the added `access-spack-packages-ref` is appropriate
- [x] Validate if maintainers want to move to `spack v1` over `spack v0.22`
