### PR TITLE
Add `ferrmax` to `thermo_nml` namelist

### DIFF
--- a/source/ice_init.F90
+++ b/source/ice_init.F90
@@ -100,7 +100,7 @@
       use ice_meltpond_lvl, only: restart_pond_lvl, dpscale, frzpnd, &
                                   rfracmin, rfracmax, pndaspect, hs1
       use ice_aerosol, only: restart_aero
-      use ice_therm_shared, only: ktherm, calc_Tsfc, conduct
+      use ice_therm_shared, only: ktherm, calc_Tsfc, conduct, ferrmax
       use ice_therm_vertical, only: ustar_min, fbot_xfer_type
       use ice_therm_mushy, only: a_rapid_mode, Rac_rapid_mode, aspect_rapid_mode, &
                                  dSdt_slow_mode, phi_c_slow_mode, &
@@ -158,7 +158,7 @@
 #ifdef AusCOM
 	chio,                                                           &
 #endif
-        dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy
+        dSdt_slow_mode, phi_c_slow_mode, phi_i_mushy, ferrmax
 
       namelist /dynamics_nml/ &
         kdyn,           ndte,           revised_evp,    yield_curve,    &
@@ -285,6 +285,8 @@
       calc_Tsfc = .true.     ! calculate surface temperature
       update_ocn_f = .false. ! include fresh water and salt fluxes for frazil
       ustar_min = 0.005      ! minimum friction velocity for ocean heat flux (m/s)
+      ferrmax = 1.0e-3_dbl_kind   ! max allowed energy flux error (W m-2)
+                                  ! recommend ferrmax < 0.01 W m-2
       l_mpond_fresh = .false.     ! logical switch for including meltpond freshwater
                                   ! flux feedback to ocean model
       fbot_xfer_type = 'constant' ! transfer coefficient type for ocn heat flux

--- a/source/ice_therm_shared.F90
+++ b/source/ice_therm_shared.F90
@@ -27,9 +27,9 @@
          Tmlt            ! melting temperature
                          ! nilyr + 1 index is for bottom surface
 
-      real (kind=dbl_kind), parameter, public :: &
-         ferrmax = 1.0e-3_dbl_kind    ! max allowed energy flux error (W m-2)
-                                      ! recommend ferrmax < 0.01 W m-2
+      real (kind=dbl_kind), public :: &
+         ferrmax         ! max allowed energy flux error (W m-2)
+                         ! recommend ferrmax < 0.01 W m-2
 
       real (kind=dbl_kind), parameter, public :: &
          Tmin = -100.0_dbl_kind ! min allowed internal temperature (deg C)


### PR DESCRIPTION
This PR adds `ferrmax` to the `thermo_nml` namelist so that the threshold can be modified at runtime.

Closes #86