### PR TITLE
Nesi changes to AVX2 flags

### DIFF
--- a/bld/Macros.nci
+++ b/bld/Macros.nci
@@ -21,7 +21,7 @@ ifeq ($(DEBUG), 1)
     FFLAGS          := $(NCI_INTEL_FLAGS) $(NCI_REPRO_FLAGS) $(NCI_DEBUG_FLAGS)
     CPPDEFS         := $(CPPDEFS) -DDEBUG=$(DEBUG)
 else
-    NCI_OPTIM_FLAGS := -g3 -O2 -axCORE-AVX2 -debug all -check none -qopt-report=5 -qopt-report-annotate -assume buffered_io
+    NCI_OPTIM_FLAGS := -g3 -O2 -mavx2 -debug all -check none -qopt-report=5 -qopt-report-annotate -assume buffered_io
     FFLAGS          := $(NCI_INTEL_FLAGS) $(NCI_REPRO_FLAGS) $(NCI_OPTIM_FLAGS)
 endif
 


### PR DESCRIPTION
Changes to AVX2 flags for NeSI. Note: I don't think I managed to successfully update the flags during compilation, but it still seemed to work. I was trying to make sure the all references to -axCORE-AVX2 were changed to -mavx2. This seemed to matter for MOM5 compilation, but not for CICE5. Don't know why. But anyway, context can be found here:
https://forum.access-hive.org.au/t/installing-access-om2-on-nesi-new-zealand-supercomputer/5566/53