### PR TITLE
Use double precision for time bounds. Drop bounds from instantaneous output 

### DIFF
--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -348,7 +348,7 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
         dimid(1) = boundid
         dimid(2) = timid
         call check(nf90_def_var(ncid, 'time_bounds', &
-                              nf90_float,dimid(1:2),varid), &
+                              nf90_double,dimid(1:2),varid), &
                     'def var time_bounds')
 
         call check(nf90_put_att(ncid,varid,'long_name', &

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -160,7 +160,7 @@ subroutine ice_write_hist (ns)
       ! write time_bounds info
       !-----------------------------------------------------------------
 
-        if (hist_avg) then
+        if (hist_avg .and. histfreq(ns) /= '1') then
             call check(nf90_inq_varid(ncid,'time_bounds',varid), &
                        'inq varid time_bounds')
             if (history_parallel_io) then
@@ -335,7 +335,7 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
           call abort_ice( 'ice Error: invalid calendar settings')
       endif
 
-      if (hist_avg) then
+      if (hist_avg .and. histfreq(ns) /= '1') then
           call check(nf90_put_att(ncid,varid,'bounds','time_bounds'), &
                       'att time bounds')
       endif
@@ -344,7 +344,7 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
     ! Define attributes for time bounds if hist_avg is true
     !-----------------------------------------------------------------
 
-      if (hist_avg) then
+      if (hist_avg .and. histfreq(ns) /= '1') then
         dimid(1) = boundid
         dimid(2) = timid
         call check(nf90_def_var(ncid, 'time_bounds', &

--- a/io_pio/ice_history_write.F90
+++ b/io_pio/ice_history_write.F90
@@ -323,7 +323,7 @@ subroutine ice_hist_create(ns, ncfile, File, var, coord_var, var_nverts, var_nz)
             dimid(1) = boundid
             dimid(2) = timid
             call ice_pio_check(pio_def_var(File, 'time_bounds', &
-                                 pio_real,dimid(1:2),varid), &
+                                 pio_double,dimid(1:2),varid), &
                         'def var time_bounds')
 
             call ice_pio_check(pio_put_att(File,varid,'long_name', &

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -1893,7 +1893,6 @@
            avgct(ns) = avgct(ns) + c1
            if (avgct(ns) == c1) then
               time_beg(ns) = (time-dt)/int(secday)
-              time_beg(ns) = real(time_beg(ns),kind=real_kind)
            endif
          endif
       enddo  ! ns
@@ -3321,7 +3320,6 @@
         !$OMP END PARALLEL DO
 
         time_end(ns) = time/int(secday)
-        time_end(ns) = real(time_end(ns),kind=real_kind)
 
       !---------------------------------------------------------------
       ! write file

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -132,7 +132,7 @@
          nvarz = 4              , & ! number of category/vertical grid fields written
          ncat_hist = ncat           ! number of ice categories written <= ncat
 
-      real (kind=real_kind), public :: time_beg(max_nstrm), & ! bounds for averaging
+      real (kind=dbl_kind), public :: time_beg(max_nstrm), & ! bounds for averaging
                                        time_end(max_nstrm), &
                                        time_bounds(2)
 


### PR DESCRIPTION
Closes #96.

### Time bounds precision:
The time variable uses double precision while its bounds use single precision. When the time is large relative to the origin,  inaccurate bounds can be written to the output files for hourly data. E.g. for ESM1.6:

```
$ ncdump -h iceh-1hourly-mean_0272-01.nc 
...
 time = "1850-01-01 02", "1850-01-01 03", "1850-01-01 04", "1850-01-01 05", 


$  ncdump -t -v time_bounds iceh-1hourly-mean_1850-01.nc 
 time_bounds =
  "1850-01-01", "1850-01-01 01:30",
  "1850-01-01 01:30", "1850-01-01 03",
  "1850-01-01 03", "1850-01-01 04:30",
  "1850-01-01 04:30", "1850-01-01 04:30",
```

This PR swaps the time bounds variables to use double precision. With the changes, we get:
```
 time_bounds =
  "1850-01-01", "1850-01-01 02",
  "1850-01-01 02", "1850-01-01 03",
  "1850-01-01 03", "1850-01-01 04",
```

Using the `release-1deg_jra55_iaf` branch for OM2 there aren't any immediate differences in the bounds, as the time origin is much closer to the data:

Without changes
```
time_bounds =
  "1958-01-01", "1958-01-01 03",
  "1958-01-01 03", "1958-01-01 04:30",
  "1958-01-01 04:30", "1958-01-01 06",
```

With changes
```
 time_bounds =
  "1958-01-01", "1958-01-01 03",
  "1958-01-01 03", "1958-01-01 04:30",
  "1958-01-01 04:30", "1958-01-01 06",
```

### Bounds on instantaneous data 
For the netCDF io, the lower time bound for single timestep data is also off:
```
$ ncdump -t -v time_bounds iceh-1-mean_1850-01.nc 
time_bounds =
  "0001-01-01", "1850-01-01 01:30",
  "0001-01-01", "1850-01-01 01:30",
  "0001-01-01", "1850-01-01 03",
  "0001-01-01", "1850-01-01 04:30",
  "0001-01-01", "1850-01-01 04:30",
```



The `io_pio/ice_history_write.F90` code already [omits time bounds](https://github.com/ACCESS-NRI/cice5/blob/31f38443cf796e13d656351a8210dbcc454de2bf/io_pio/ice_history_write.F90#L153-L160) for `histfreq(ns) == 1`. 

Following discussion, it makes sense for instantaneous data to not have time bounds. This PR modifies the `io_netcdf/ice_history_write.F90` module so that time bounds are omitted for instantaneous output, matching the behaviour of `io_pio/ice_history_write.F90`.


### Unaddressed issues
There are still a couple of odd things with the hourly data:
* It seems to skip the first hour:
   ```
    ncdump -h iceh-1hourly-mean_1850-01.nc
    time = "1850-01-01 02", "1850-01-01 03", "1850-01-01 04", "1850-01-01 05", 
   ```
   which might be related to [this line](https://github.com/ACCESS-NRI/cice5/blob/31f38443cf796e13d656351a8210dbcc454de2bf/source/ice_calendar.F90#L314). I'm not sure whether we'd like to address this here.
* Each run produces two output files for hourly output. The second only contains the single timestep at the boundary of the month/year:
   ```
   $ ls archive/output000/ice
   i eh-1hourly-mean_1850-01.nc  iceh-1hourly-mean_1850-02.nc  iceh-1monthly-mean_1850-01.nc iceh-1daily-mean_1850-01.nc  iceh-1-mean_1850-01.nc 
   ```
   Though I'm not sure how much we can do about this.



