### PR TITLE
Add siitdthick diagnostic

### DIFF
--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -764,7 +764,7 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
                 ! Add cell_methods attribute to variables if averaged
                 !---------------------------------------------------------------
                 if (hist_avg .and. histfreq(ns) /= '1') then
-                    if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .or. &
+                    if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .and. &
                         TRIM(avail_hist_fields(n)%vname)/='keffn_top') then
                         if (avail_hist_fields(n)%avg_ice_present) then
                             call check(nf90_put_att(ncid,varid,'cell_methods',&

--- a/io_netcdf/ice_history_write.F90
+++ b/io_netcdf/ice_history_write.F90
@@ -676,6 +676,8 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
                                 'put att cell methods time mean '//avail_hist_fields(n)%vname)
                             endif
                         endif
+                        call check(nf90_put_att(ncid,varid,'time_rep','averaged'), &
+                            'put att time_rep averaged')
                     endif
                 endif
 
@@ -701,10 +703,9 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
                             'put att cell methods '//avail_hist_fields(n)%vname)
                         endif
                     endif
-                else
-                    call check(nf90_put_att(ncid,varid,'time_rep','averaged'), &
-                               'put att time_rep averaged')
                 endif
+
+
             endif
         enddo  ! num_avail_hist_fields_2D
 
@@ -763,16 +764,48 @@ subroutine ice_hist_create(ns, ncfile, ncid, var, coord_var, var_nverts, var_nz)
                 ! Add cell_methods attribute to variables if averaged
                 !---------------------------------------------------------------
                 if (hist_avg .and. histfreq(ns) /= '1') then
-                    status = nf90_put_att(ncid,varid,'cell_methods','time: mean')
-                    if (status /= nf90_noerr) call abort_ice( &
-                     'Error defining cell methods for '//avail_hist_fields(n)%vname)
+                    if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .or. &
+                        TRIM(avail_hist_fields(n)%vname)/='keffn_top') then
+                        if (avail_hist_fields(n)%avg_ice_present) then
+                            call check(nf90_put_att(ncid,varid,'cell_methods',&
+                                'area: time: mean where sea_ice (mask=siitdconc)'), &
+                                'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                        else
+                            if (TRIM(avail_hist_fields(n)%vname(1:2))/='si') then !native diags
+                                call check(nf90_put_att(ncid,varid,'cell_methods','time: mean'), &
+                                'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                            else !cmip diags
+                                call check(nf90_put_att(ncid,varid,'cell_methods', &
+                                'area: mean where sea time: mean'), &
+                                'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                            endif
+                        endif
+                        call check(nf90_put_att(ncid,varid,'time_rep','averaged'), &
+                             'put att time_rep averaged')
+                    endif
                 endif
 
-                if (histfreq(ns) == '1' .or. .not. hist_avg) then
-                    status = nf90_put_att(ncid,varid,'time_rep','instantaneous')
-                else
-                    status = nf90_put_att(ncid,varid,'time_rep','averaged')
+                if (histfreq(ns) == '1' .or. .not. hist_avg         &
+                    .or. n==n_Tn_top(ns) .or. n==n_keffn_top(ns)) then ! snapshots
+                    call check(nf90_put_att(ncid,varid,'time_rep','instantaneous'), &
+                               'put att time_rep instantaneous')
+                    if (avail_hist_fields(n)%avg_ice_present) then
+                        call check(nf90_put_att(ncid,varid,'cell_methods',&
+                            'area: mean where sea_ice (mask=siitdconc) time: point'), &
+                            'put att cell methods'//avail_hist_fields(n)%vname)
+                    else
+                        if (TRIM(avail_hist_fields(n)%vname(1:2))/='si') then !native diags
+                            call check(nf90_put_att(ncid,varid,'cell_methods','time: point'), &
+                            'put att cell methods'//avail_hist_fields(n)%vname)
+                        else !cmip diags
+                            call check(nf90_put_att(ncid,varid,'cell_methods', &
+                            'area: mean where sea time: point'), &
+                            'put att cell methods '//avail_hist_fields(n)%vname)
+                        endif
+                    endif
                 endif
+
+
             endif
         enddo  ! num_avail_hist_fields_3Dc
 

--- a/io_pio/ice_history_write.F90
+++ b/io_pio/ice_history_write.F90
@@ -748,7 +748,7 @@ subroutine ice_hist_create(ns, ncfile, File, var, coord_var, var_nverts, var_nz)
                ! Add cell_methods and time_rep attributes
                !---------------------------------------------------------------
                if (hist_avg .and. histfreq(ns) /= '1') then
-                   if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .or. &
+                   if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .and. &
                         TRIM(avail_hist_fields(n)%vname)/='keffn_top') then
                      if (avail_hist_fields(n)%avg_ice_present) then
                         call ice_pio_check(pio_put_att(File,varid,'cell_methods',&

--- a/io_pio/ice_history_write.F90
+++ b/io_pio/ice_history_write.F90
@@ -657,6 +657,8 @@ subroutine ice_hist_create(ns, ncfile, File, var, coord_var, var_nverts, var_nz)
                               'put att cell methods time mean '//avail_hist_fields(n)%vname)
                            endif
                      endif
+                     call ice_pio_check(pio_put_att(File,varid,'time_rep','averaged'), &
+                          'put att time_rep averaged')
                   endif
                endif
 
@@ -682,9 +684,7 @@ subroutine ice_hist_create(ns, ncfile, File, var, coord_var, var_nverts, var_nz)
                         'put att cell methods  '//avail_hist_fields(n)%vname)
                      endif
                   endif
-               else
-                  call ice_pio_check(pio_put_att(File,varid,'time_rep','averaged'), &
-                              'put att time_rep averaged')
+
                endif
             endif
       enddo  ! num_avail_hist_fields_2D
@@ -743,20 +743,53 @@ subroutine ice_hist_create(ns, ncfile, File, var, coord_var, var_nverts, var_nz)
                if (status /= nf90_noerr) call abort_ice( &
                   'Error defining _FillValue for '//avail_hist_fields(n)%vname)
 
+
                !---------------------------------------------------------------
-               ! Add cell_methods attribute to variables if averaged
+               ! Add cell_methods and time_rep attributes
                !---------------------------------------------------------------
                if (hist_avg .and. histfreq(ns) /= '1') then
-                  status = pio_put_att(File,varid,'cell_methods','time: mean')
-                  if (status /= nf90_noerr) call abort_ice( &
-                     'Error defining cell methods for '//avail_hist_fields(n)%vname)
+                   if (TRIM(avail_hist_fields(n)%vname)/='Tn_top' .or. &
+                        TRIM(avail_hist_fields(n)%vname)/='keffn_top') then
+                     if (avail_hist_fields(n)%avg_ice_present) then
+                        call ice_pio_check(pio_put_att(File,varid,'cell_methods',&
+                           'area: time: mean where sea_ice (mask=siitdconc)'), &
+                           'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                     else
+                           if (TRIM(avail_hist_fields(n)%vname(1:2))/='si') then !native diags
+                              call ice_pio_check(pio_put_att(File,varid,'cell_methods','time: mean'), &
+                              'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                           else !cmip diags
+                              call ice_pio_check(pio_put_att(File,varid,'cell_methods', &
+                              'area: mean where sea time: mean'), &
+                              'put att cell methods time mean '//avail_hist_fields(n)%vname)
+                           endif
+                     endif
+                        call ice_pio_check(pio_put_att(File,varid,'time_rep','averaged'), &
+                             'put att time_rep averaged')
+                  endif
                endif
 
-               if (histfreq(ns) == '1' .or. .not. hist_avg) then
-                  status = pio_put_att(File,varid,'time_rep','instantaneous')
-               else
-                  status = pio_put_att(File,varid,'time_rep','averaged')
+               if (histfreq(ns) == '1' .or. .not. hist_avg         &
+                  .or. n==n_Tn_top(ns) .or. n==n_keffn_top(ns)) then ! snapshots
+                  call ice_pio_check(pio_put_att(File,varid,'time_rep','instantaneous'), &
+                              'put att time_rep instantaneous')
+                  if (avail_hist_fields(n)%avg_ice_present) then
+                     call ice_pio_check(pio_put_att(File,varid,'cell_methods',&
+                        'area: mean where sea_ice (mask=siitdconc) time: point'), &
+                        'put att cell methods '//avail_hist_fields(n)%vname)
+                  else
+                     if (TRIM(avail_hist_fields(n)%vname(1:2))/='si') then !native diags
+                        call ice_pio_check(pio_put_att(File,varid,'cell_methods','time: point'), &
+                        'put att cell methods '//avail_hist_fields(n)%vname)
+                     else !cmip diags
+                        call ice_pio_check(pio_put_att(File,varid,'cell_methods', &
+                        'area: mean where sea time: point'), &
+                        'put att cell methods  '//avail_hist_fields(n)%vname)
+                     endif
+                  endif
                endif
+
+
             endif
       enddo  ! num_avail_hist_fields_3Dc
 

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -1558,6 +1558,11 @@
               "none", c100, c0,                  &
               ns1, f_siitdconc)
 
+            call define_hist_field(n_siitdthick,"siitdthick","m",tstr3Dc, tcstr, &
+              "Sea-Ice thickness in ice thickness categories", &
+              "none", c1, c0,                  &
+              ns1, f_siitdthick, avg_ice_present=.true., mask_ice_free_points=.true.)
+
             ! siitdthick, siitdsnconc, siitdsnthick are not implemented because it's not clear how to 
             ! mask them when ice free (e.g. by aice or aicen ? )
 
@@ -3109,8 +3114,10 @@
                 enddo             ! j
                 enddo             ! k
 
-                ! To-do: if (avail_hist_fields(n)%mask_ice_free_points) returns true, would 
-                ! we mask by aice or aicen ?
+                ! Mask ice-free points by aicen
+                if (avail_hist_fields(n)%mask_ice_free_points) then
+                  where(ravgipn(:,:,:) == c0) a3Dc(:,:,:,n,iblk) = spval_dbl
+                endif
 
               endif
 

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -461,6 +461,7 @@
       call broadcast_scalar (f_siforceintstrx, master_task)
       call broadcast_scalar (f_siforceintstry, master_task)
       call broadcast_scalar (f_siitdconc, master_task)
+      call broadcast_scalar (f_siitdthick, master_task)
       call broadcast_scalar (f_aicen, master_task)
       call broadcast_scalar (f_vicen, master_task)
       call broadcast_scalar (f_vsnon, master_task)

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -3095,7 +3095,7 @@
               if (avail_hist_fields(nn)%vhistfreq == histfreq(ns)) then
 
                 ! Only average for timesteps when ice present
-                if (avail_hist_fields(n)%avg_ice_present) then
+                if (avail_hist_fields(nn)%avg_ice_present) then
                     a3Dc(:,:,:,n,iblk) = a3Dc(:,:,:,n,iblk)*ravgipn(:,:,:)
                 else
                     a3Dc(:,:,:,n,iblk) = a3Dc(:,:,:,n,iblk)*ravgct
@@ -3115,7 +3115,7 @@
                 enddo             ! k
 
                 ! Mask ice-free points by aicen
-                if (avail_hist_fields(n)%mask_ice_free_points) then
+                if (avail_hist_fields(nn)%mask_ice_free_points) then
                   where(ravgipn(:,:,:) == c0) a3Dc(:,:,:,n,iblk) = spval_dbl
                 endif
 

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -2797,6 +2797,10 @@
          if (f_siitdconc   (1:1) /= 'x') &
              call accum_hist_field(n_siitdconc-n2D, iblk, ncat_hist, &
                                    aicen(:,:,1:ncat_hist,iblk), a3Dc)
+        if (f_siitdthick   (1:1) /= 'x') &
+            ! intensive + category area mean -> use weighted form
+             call accum_hist_field(n_siitdthick-n2D, iblk, ncat_hist, &
+                                   vicen(:,:,1:ncat_hist,iblk), a3Dc)
 ! example for 3D field (x,y,z)
 !         if (f_field3dz   (1:1) /= 'x') &
 !             call accum_hist_field(n_field3dz-n3Dccum, iblk, nzilyr, &

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -1561,7 +1561,7 @@
 
             call define_hist_field(n_siitdthick,"siitdthick","m",tstr3Dc, tcstr, &
               "Sea-Ice thickness in ice thickness categories", &
-              "none", c1, c0,                  &
+              "area weighted average of volume divided by ice area in each thickness category", c1, c0,                  &
               ns1, f_siitdthick, avg_ice_present=.true., mask_ice_free_points=.true.)
 
             ! siitdthick, siitdsnconc, siitdsnthick are not implemented because it's not clear how to 

--- a/source/ice_history.F90
+++ b/source/ice_history.F90
@@ -2970,7 +2970,7 @@
            do k=1,ncat_hist
            do j = jlo, jhi
            do i = ilo, ihi
-              if (a3Dc(i,j,k,n_aicen(ns)-n2D,iblk) > puny) then
+              if (a3Dc(i,j,k,n_aicen(ns)-n2D,iblk) * ravgct > area_threshold) then
                  ravgipn(i,j,k) = c1/(a3Dc(i,j,k,n_aicen(ns)-n2D,iblk))
               else
                  ravgipn(i,j,k) = c0

--- a/source/ice_history_shared.F90
+++ b/source/ice_history_shared.F90
@@ -301,7 +301,7 @@
            f_siflfwdrain = 'x', &
            f_sisaltmass = 'x', &
            f_aicen     = 'x' , f_siitdconc = 'x', &
-           f_vicen      = 'x', &
+           f_vicen      = 'x', f_siitdthick = 'x',&
            f_vsnon     = 'x',  &
            f_trsig     = 'm', &
            f_icepresent = 'm', f_sitimefrac = 'x',&
@@ -438,7 +438,7 @@
            f_siflfwdrain, &
            f_sisaltmass, &
            f_aicen, f_siitdconc, &    
-           f_vicen, &
+           f_vicen, f_siitdthick, &
            f_vsnon, &
            f_trsig, &
            f_icepresent, f_sitimefrac,& !same var, two names
@@ -579,6 +579,7 @@
            n_siflfwdrain, &
            n_sisaltmass, &
            n_siitdconc, &
+           n_siitdthick, &
            n_vsnon,                        &
            n_fhocn      , n_fhocn_ai   , &
            n_fswthru    , n_fswthru_ai , &


### PR DESCRIPTION
This PR adds category sea ice thickness as an output variable. This is treated as an intensive variable, calculated as a weighted average of the actual ice height in meters, using the category ice fractions as the weights.

The output is masked according to the category sea ice concentration `siitdconc`, so that it will be NaN wherever there is no ice in a given category.

The PR includes changes to the `ice_history_write.F90` files, in order to correctly set the cell methods to `area: time: mean where sea_ice (mask=siitdconc)`

I'll start this PR off as a draft while we resolve the issue with the model stalling.
