### PR TITLE
Update and fix CI manifests

### DIFF
--- a/.github/build-ci/manifests/gcc-cice5.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5.spack.yaml.j2
@@ -2,6 +2,7 @@ spack:
   specs:
   - 'cice5@git.{{ ref }}=stable {{ om2_2deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-om2'
+  - 'cice5@git.{{ ref }}=stable model=access-esm1.6'
   packages:
     gcc:
       require:

--- a/.github/build-ci/manifests/gcc-cice5.spack.yaml.j2
+++ b/.github/build-ci/manifests/gcc-cice5.spack.yaml.j2
@@ -7,7 +7,7 @@ spack:
       require:
       - '{{ gcc_compiler_ver }}'
     all:
-      prefer:
+      require:
       - '%access_gcc'
       - 'target={{ target }}'
   concretizer:

--- a/.github/build-ci/manifests/intel-cice5.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5.spack.yaml.j2
@@ -3,6 +3,7 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_2deg }}'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_2deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-om2'
+  - 'cice5@git.{{ ref }}=stable model=access-esm1.6'
   packages:
     intel-oneapi-compilers-classic:
       require:

--- a/.github/build-ci/manifests/intel-cice5.spack.yaml.j2
+++ b/.github/build-ci/manifests/intel-cice5.spack.yaml.j2
@@ -8,7 +8,7 @@ spack:
       require:
       - '{{ intel_compiler_ver }}'
     all:
-      prefer:
+      require:
       - '%access_intel'
       - 'target={{ target }}'
   concretizer:

--- a/.github/build-ci/manifests/oneapi-cice5-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-esm1p6.spack.yaml.j2
@@ -4,6 +4,7 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ esm1p6_0p5deg }} ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ esm1p6_0p5deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-esm1.6'
+  - 'access-esm1p6 ^cice5@git.{{ ref }}=stable ^cable@2025.11.000 library=access-esm1.6'
   packages:
     intel-oneapi-compilers:
       require:

--- a/.github/build-ci/manifests/oneapi-cice5-esm1p6.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-esm1p6.spack.yaml.j2
@@ -9,7 +9,7 @@ spack:
       require:
       - '{{ oneapi_compiler_ver }}'
     all:
-      prefer:
+      require:
       - '%access_oneapi'
       - 'target={{ target }}'
   concretizer:

--- a/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
@@ -1,8 +1,8 @@
 spack:
   specs:
-  - 'cice5@git.{{ ref }}=stable {{ om2_1deg }} io_type=PIO ^openmpi@4'
-  - 'cice5@git.{{ ref }}=stable {{ om2_1deg }} io_type=NetCDF ^openmpi@5'
-  - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
+  - 'cice5@git.{{ ref }}=stable {{ om2_2deg }} io_type=PIO ^openmpi@4'
+  - 'cice5@git.{{ ref }}=stable {{ om2_2deg }} io_type=NetCDF ^openmpi@5'
+  - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_2deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
     intel-oneapi-compilers:

--- a/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
@@ -4,13 +4,12 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_1deg }} io_type=NetCDF ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_1deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-om2'
-  - 'cice5@git.{{ ref }}=stable model=access-om2'
   packages:
     intel-oneapi-compilers:
       require:
       - '{{ oneapi_compiler_ver }}'
     all:
-      prefer:
+      require:
       - '%access_oneapi'
       - 'target={{ target }}'
   concretizer:

--- a/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi-cice5-om2.spack.yaml.j2
@@ -4,6 +4,7 @@ spack:
   - 'cice5@git.{{ ref }}=stable {{ om2_2deg }} io_type=NetCDF ^openmpi@5'
   - 'cice5@git.{{ ref }}=stable build_type=Debug {{ om2_2deg }}'
   - 'cice5@git.{{ ref }}=stable model=access-om2'
+  - 'access-om2 ^cice5@git.{{ ref }}=stable'
   packages:
     intel-oneapi-compilers:
       require:


### PR DESCRIPTION
We want to delete the CICE5 CI manifests in `access-spack-packages`. First we need to ensure we don't lose any CI coverage by copying any specs that are missing specs into this repository's CI manifests.

This PR is blocking https://github.com/ACCESS-NRI/access-spack-packages/pull/463